### PR TITLE
Override indexing functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,14 @@ PyTorch models are typically trained and evaluated on batches of data. However, 
       - operations that reduce the batch dimension (e.g. `torch.sum`): Reduce also the attributes along the batch dim. This happens in losses.
       - operations that create new dimensions: Adjust `batch_dim` and `stream_dim` accordlingly. This could happen anywhere.
   - Seperate arguments to forward method: We can change all patched forward methods to take additional arguments, but, by default they won't be given (and we have no control).
+- How do we deal with operations that are invalid on one or more StreamTensors?
+  - Examples:
+    - Adding two StreamTensors with different `ids`.
+    - Combining batch or length dimensions with one or more other dimensions into a single dimension using e.g. `torch.reshape`, `torch.flatten` or masked indexing.
+  - Options:
+    - Fail outright.
+    - Fallback to a regular `torch.Tensor`.
+    - Fallback to a different tensor subclass that is identical in behaviour to `torch.Tensor` but carries the frozen `StreamMetadata` along.
 
 ## Can we use DreamStream for training?
 

--- a/dreamstream/__init__.py
+++ b/dreamstream/__init__.py
@@ -1,3 +1,4 @@
+import dreamstream.overrides  # noqa: F401
 import dreamstream.random  # noqa: F401
-from dreamstream.overrides import *  # noqa: F403
+
 from dreamstream.tensor import StreamMetadata, StreamTensor, as_stream_tensor, stream_tensor  # noqa: F401

--- a/dreamstream/data/stream_dataset.py
+++ b/dreamstream/data/stream_dataset.py
@@ -24,7 +24,7 @@ LOGGER = logging.getLogger(__file__)
 
 
 # TODO (JDH): Add boolean flag to switch between starting a new call as soon as the previous one ends, or waiting for
-# all calls of the previous batch to end before starting new calls.
+# all calls of the previous batch to end before starting new calls. Current behavior is the former.
 
 
 def partition_by_sum(

--- a/dreamstream/func_coverage.py
+++ b/dreamstream/func_coverage.py
@@ -24,6 +24,8 @@ RECOUPLE_FUNCTIONS = {
     torch.sigmoid,
     torch.Tensor.sigmoid,
     torch.transpose,
+    torch.where,
+    torch.Tensor.where,
 }
 
 # The full set of functions that are explicitly supported for StreamTensors.

--- a/dreamstream/func_coverage.py
+++ b/dreamstream/func_coverage.py
@@ -29,6 +29,12 @@ RECOUPLE_FUNCTIONS = {
     torch.scatter,
     torch.Tensor.scatter,
     torch.Tensor.scatter_,
+    torch.diagonal_scatter,
+    torch.Tensor.diagonal_scatter,
+    torch.select_scatter,
+    torch.Tensor.select_scatter,
+    torch.slice_scatter,
+    torch.Tensor.slice_scatter,
 }
 
 # The full set of functions that are explicitly supported for StreamTensors.

--- a/dreamstream/func_coverage.py
+++ b/dreamstream/func_coverage.py
@@ -26,6 +26,9 @@ RECOUPLE_FUNCTIONS = {
     torch.transpose,
     torch.where,
     torch.Tensor.where,
+    torch.scatter,
+    torch.Tensor.scatter,
+    torch.Tensor.scatter_,
 }
 
 # The full set of functions that are explicitly supported for StreamTensors.

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -684,6 +684,21 @@ def select(input: StreamTensor, dim: int, index: Union[None, int, slice, Tensor,
     return input.__getitem__(getitem_index)
 
 
+@implements(torch.index_select)
+@implements(torch.Tensor.index_select)
+def index_select(input: StreamTensor, dim: int, index: Tensor, *, out: Optional[torch.Tensor] = None):
+    tensor, meta, names = input.decouple()
+    out = torch.index_select(tensor, dim, index, out=out)
+
+    if dim == names.index(BATCH):
+        meta = meta[index]
+    elif dim == names.index(LENGTH):
+        meta = meta[:, index]
+
+    out.rename_(*names)
+    return StreamTensor(out, meta)
+
+
 @implements(torch.masked_select)
 def masked_select(input: StreamTensor, mask: Tensor, *, out: Optional[torch.Tensor] = None):
     tensor, meta, names = input.decouple()
@@ -825,9 +840,9 @@ def unqsqueeze(input: StreamTensor, dim: int) -> StreamTensor:
 # X @implements(torch.narrow)
 
 # X @implements(torch.scatter)
-# @implements(torch.diagonal_scatter)
-# @implements(torch.select_scatter)
-# @implements(torch.slice_scatter)
+# X @implements(torch.diagonal_scatter)
+# X @implements(torch.select_scatter)
+# X @implements(torch.slice_scatter)
 
 # X @implements(torch.scatter_add)
 # X @implements(torch.scatter_add_)
@@ -837,7 +852,7 @@ def unqsqueeze(input: StreamTensor, dim: int) -> StreamTensor:
 # X @implements(torch.select)  # Equivalent to slicing with torch.Tensor.__getitem__
 # X @implements(torch.select_copy)
 
-# @implements(torch.index_select)
+# X @implements(torch.index_select)
 # X @implements(torch.masked_select)
 # X @implements(torch.take)
 # X @implements(torch.take_along_dim)
@@ -877,5 +892,5 @@ def unqsqueeze(input: StreamTensor, dim: int) -> StreamTensor:
 # @implements(torch.unique)
 
 # moving dimensions
-# @implements(torch.transpose)
-# @implements(torch.permute)
+# X @implements(torch.transpose)
+# X @implements(torch.permute)

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -686,7 +686,7 @@ def select(input: StreamTensor, dim: int, index: Union[None, int, slice, Tensor,
     # TODO (JDH): Separate out torch.select and torch.Tensor.select which return views of the original data instead.
     dim = dim if dim >= 0 else input.ndim + dim
     getitem_index = (slice(None),) * dim + (index,)
-    return input.__getitem__(*getitem_index)
+    return input.__getitem__(getitem_index)
 
 
 @implements(torch.masked_select)

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -1,13 +1,14 @@
 import functools
 from copy import deepcopy
-from typing import Any, Callable, Optional, List, Tuple, Union
+from typing import Any, Callable, NamedTuple, Optional, List, Sequence, Tuple, Union
+from torch.types import Number
 
 import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor
 
-from dreamstream.tensor import StreamTensor, StreamMetadata
+from dreamstream.tensor import StreamTensor, StreamMetadata, decouple_recursive
 from dreamstream.func_coverage import OVERRIDDEN_FUNCTIONS
 from dreamstream.utils.flags import BATCH, LENGTH
 from dreamstream.warnings import fallback_operation_warning
@@ -137,18 +138,6 @@ def split(tensor: StreamTensor, split_size_or_sections: Union[int, List[int]], d
     return tensors
 
 
-# @implements(torch.tensor_split)
-# @implements(torch.Tensor.tensor_split)
-# def tensor_split(tensor: StreamTensor, indices_or_sections: Union[int, List[int]], dim: int = 0):
-#     raise NotImplementedError("tensor_split is not implemented for StreamTensor.")
-
-
-# @implements(torch.chunk)
-# @implements(torch.Tensor.chunk)
-# def chunk(tensor: StreamTensor, chunks: int, dim=0) -> List[StreamTensor]:
-#     raise NotImplementedError("chunk is not implemented for StreamTensor.")
-
-
 @implements(torch.unbind)
 @implements(torch.Tensor.unbind)
 def unbind(tensor: StreamTensor, dim=0) -> List[StreamTensor]:
@@ -244,17 +233,11 @@ def conv1d(
     return StreamTensor(output, meta), buffer
 
 
-def is_indexing_multidimensional(indices: Union[None, int, slice, List[Any], Tuple[Any, ...]]):
-    """Return True if any of the indices are multidimensional, i.e. not an int, slice, or list/tuple of ints but
-    instead a list or tuple of those."""
-    return (
-        indices is Ellipsis
-        or (isinstance(indices, tuple))
-        or (isinstance(indices, list) and not all(isinstance(i, (int, bool)) for i in indices))
-    )
+IntegerTensorType = Union[torch.ByteTensor, torch.CharTensor, torch.ShortTensor, torch.IntTensor, torch.LongTensor]
+IndexingType = Union[None, int, slice, List[int], Tuple[int, ...], torch.BoolTensor, IntegerTensorType]
 
 
-def get_locations_of_multidimensional_booltensors(indices: Union[List[Any], Tuple[Any, ...]]) -> List[int]:
+def get_locations_of_multidimensional_booltensors(indices: Sequence[IndexingType]) -> List[int]:
     """Return the locations (linear index into `indices`) of any multidimensional booltensors"""
     indexes = []
     for i, index in enumerate(indices):
@@ -263,7 +246,12 @@ def get_locations_of_multidimensional_booltensors(indices: Union[List[Any], Tupl
     return indexes
 
 
-def replace_ellipsis(indices: Union[Tuple[Any, ...], List[Any]], ndim: int) -> List[Any]:
+def number_of_indexed_dimensions(indices: Sequence[IndexingType]) -> int:
+    """Return the number of dimensions that are indexed, i.e. not None."""
+    return sum(1 for i in indices if i is not None)
+
+
+def replace_ellipsis(indices: Sequence[IndexingType], ndim: int) -> List[Any]:
     """Replace Ellipsis in indices with the equivalent number of slices given the dimensionality of a torch.Tensor."""
     if Ellipsis not in indices:
         return indices
@@ -271,47 +259,46 @@ def replace_ellipsis(indices: Union[Tuple[Any, ...], List[Any]], ndim: int) -> L
     # Always act on a list copy of the indices.
     if isinstance(indices, tuple):
         new_indices = list(indices)
-    else:
-        new_indices = deepcopy(indices)
 
     num_ellipsis = new_indices.count(Ellipsis)
-
-    if ndim < len(new_indices) - num_ellipsis:
-        raise IndexError(f"Too many indices for tensor of dimension {ndim}.")
 
     # If there are more than one Ellipsis, we infer the equivalent number of dimensions covered by each one.
     if num_ellipsis > 1:
         # Collapse neighboring Ellipsis into a single Ellipsis
+        # TODO (JDH): Make this more efficient without the use of `del`
         ellipsis_indices = [i for i, index in enumerate(new_indices) if index is Ellipsis]
         for i in reversed(range(num_ellipsis - 1)):
             if ellipsis_indices[i] + 1 == ellipsis_indices[i + 1]:
-                new_indices[ellipsis_indices[i]] = Ellipsis
-                del new_indices[ellipsis_indices[i] + 1]
+                new_indices.pop(ellipsis_indices[i + 1])
 
         num_ellipsis = new_indices.count(Ellipsis)
 
         # At this point, we can only handle multiple remaining Ellipsis if they each correspond to one dimension.
         if num_ellipsis > 1:
-            if len(new_indices) != ndim:
-                if len(new_indices) > ndim:
-                    raise IndexError(f"Too many indices for tensor of dimension {ndim}.")
-                raise IndexError(f"Cannot resolve Ellipsis (got {num_ellipsis} Ellipsis for {ndim} dimensions)")
+            num_indexed_dims = number_of_indexed_dimensions(new_indices)
+            if num_indexed_dims != ndim:
+                match num_indexed_dims > ndim:
+                    case True:
+                        raise IndexError(f"Too many indices for tensor of dimension {ndim}.")
+                    case False:
+                        raise IndexError(f"Cannot resolve Ellipsis (got {num_ellipsis} Ellipsis for {ndim} dimensions)")
 
             # Replace each Ellipsis with a None slice
             for i in range(num_ellipsis):
-                new_indices[ellipsis_indices[i]] = None
+                new_indices[ellipsis_indices[i]] = slice(None)
 
             return new_indices
 
     # Replace Ellipsis with as many Nones as needed to make the indices have the same length as the tensor
     ellipsis_index = new_indices.index(Ellipsis)
-    num_missing_indices = ndim - len(new_indices) + 1
-    new_indices = new_indices[:ellipsis_index] + [None] * num_missing_indices + new_indices[ellipsis_index + 1 :]
+    num_missing_indices = ndim - number_of_indexed_dimensions(new_indices) + 1
+    none_slices = [slice(None) for _ in range(num_missing_indices)]
+    new_indices = new_indices[:ellipsis_index] + none_slices + new_indices[ellipsis_index + 1 :]
 
     return new_indices
 
 
-def join_dim_names(*names: Union[Tuple[str, ...], List[str]]):
+def join_dim_names(*names: Sequence[str]) -> str:
     """Join dimension names into a single string, separated by underscores. Inverse of `split_dim_names`."""
     return "_".join(names)
 
@@ -321,11 +308,20 @@ def split_dim_names(name: str) -> Tuple[str, ...]:
     return tuple(name.split("_"))
 
 
+class IndexingDescription(NamedTuple):
+    """A description of the dimensions of a tensor that are affected by indexing with `indices`."""
+
+    ellipsis_free_indices: Union[IndexingType, Sequence[IndexingType]]
+    affected_dimensions: List[int]
+    updated_dimension_names: List[str]
+    is_multidimensional: bool
+
+
 def determine_dims_affected_by_indexing(
     names: Tuple[str, ...],
-    indices: Union[None, int, slice, Tensor, List[Any], Tuple[Any, ...]],
+    indices: Union[IndexingType, Sequence[IndexingType]],
     recursive_dim: int = None,
-) -> Tuple[List[int], Tuple[str, ...]]:
+) -> IndexingDescription:
     """Return the dimensions of the tensor that are affected by indexing with `indices`.
 
     Also returns the names of the new dimensions of the tensor that will result from the indexing.
@@ -360,71 +356,81 @@ def determine_dims_affected_by_indexing(
     is_recursive = recursive_dim is not None
     first_dim = 0 if recursive_dim is None else recursive_dim
 
-    # If indices is None, slice(None), or Ellipsis no dimensions are affected.
-    if indices is None or indices == slice(None):
-        return indices, [], [names[first_dim]] if is_recursive else names, False
+    # If indices is None, a single dimension is inserted before the first dimension, but no dimensions are affected.
+    if indices is None:
+        updated_names = [None] if is_recursive else (None,) + names
+        return IndexingDescription(indices, [], updated_names, False)
+ 
+    # If indices is slice(None), or Ellipsis no dimensions are affected.
+    if indices == slice(None):
+        updated_names = [names[first_dim]] if is_recursive else names
+        return IndexingDescription(indices, [], updated_names, False)
 
     if indices is Ellipsis:
-        if is_recursive:
-            raise RuntimeError("Ellipsis (...) should have been replaced with one or more `None` at this point...")
-        return indices, [], names, False
+        return IndexingDescription(indices, [], names, False)
 
-    # If indices is an int or a slice, or a 1D IntTensor, or a 1D BoolTensor, only the first dimension is affected.
+    # If indices is an int or a slice only the first dimension is affected.
     if isinstance(indices, int):
-        return indices, [first_dim], [] if is_recursive else [n for i, n in enumerate(names) if i != first_dim], False
+        updated_names = [] if is_recursive else [n for i, n in enumerate(names) if i != first_dim]
+        return IndexingDescription(indices, [first_dim], updated_names, False)
 
-    if isinstance(indices, slice) or (isinstance(indices, torch.Tensor) and indices.ndim == 1):
-        return indices, [first_dim], [names[first_dim]] if is_recursive else names, False
+    if isinstance(indices, slice):
+        updated_names = [names[first_dim]] if is_recursive else names
+        return IndexingDescription(indices, [first_dim], updated_names, False)
+
+    if isinstance(indices, torch.Tensor):
+        if indices.ndim == 1:
+            # If indices is a 1D IntTensor, or a 1D BoolTensor, only the first dimension is affected (as for slice, int)
+            updated_names = [names[first_dim]] if is_recursive else names
+            return IndexingDescription(indices, [first_dim], updated_names, False)
+        elif indices.dtype == torch.bool:
+            # If indices is a BoolTensor with N>1 dimensions, indexing starts from the first dimension and affects the
+            # next `indices.ndim` dimensions to the right. All affected dimensions are flattened into a single
+            # dimension with size equal to the total number of True values in `indices`.
+            joint_name = join_dim_names(*names[first_dim : first_dim + indices.ndim])
+            new_names = (joint_name,) if is_recursive else (joint_name,) + names[first_dim + indices.ndim :]
+            return IndexingDescription(indices, list(range(first_dim, first_dim + indices.ndim)), new_names, False)
+        else:
+            # If indices is an IntTensor with N>1 dimensions, N-1 new dimensions are inserted before the first
+            # dimension while only the first dimension is affected.
+            new_none_dims = (None,) * (indices.ndim - 1)
+            new_names = new_none_dims + (names[first_dim],) if is_recursive else new_none_dims + names
+            return IndexingDescription(indices, [first_dim], new_names, False)
 
     # If indices is a List[int] or a Tuple[int, ...] with `is_recursive == True`, indexing is coordinate indexing along
     # the first dimension. If indices is a Tuple[int, ...] and `is_recursive == False`, it is equivalent to
-    # `tensor[*indices]` which is handled by `is_indexing_multidimensional` case below.)
-    if (isinstance(indices, list) or (is_recursive and isinstance(indices, tuple))) and all(
+    # `tensor[*indices]` which is handled by the `isinstance(indices, Sequence)` case below, i.e. tuples are unpacked
+    # while lists are not.
+    if (isinstance(indices, list) or (isinstance(indices, tuple) and is_recursive)) and all(
         isinstance(i, (int, bool)) for i in indices
     ):
-        return indices, [first_dim], [names[first_dim]] if is_recursive else names, False
+        new_names = [names[first_dim]] if is_recursive else names
+        return IndexingDescription(indices, [first_dim], new_names, False)
 
-    # If indices is a BoolTensor with N>1 dimensions, indexing starts from the first dimension and affects the next
-    # `indices.ndim` dimensions to the right. All affected dimensions are flattened into a single dimension with size
-    # equal to the total number of True values in `indices`.
-    if isinstance(indices, torch.Tensor) and indices.dtype == torch.bool and indices.ndim > 1:
-        new_name = join_dim_names(*names[first_dim : first_dim + indices.ndim])
-        names = (new_name,) if is_recursive else (new_name,) + names[first_dim + indices.ndim :]
-        return indices, list(range(first_dim, first_dim + indices.ndim)), names, False
-
-    # If indices is an IntTensor with N>1 dimensions, N-1 new dimensions are inserted before the first dimension. But
-    # still, only the first dimension is affected.
-    if isinstance(indices, torch.Tensor) and not torch.is_floating_point(indices) and indices.ndim > 1:
-        new_none_dims = (None,) * (indices.ndim - 1)
-        names = new_none_dims + (names[first_dim],) if is_recursive else new_none_dims + names
-        return indices, [first_dim], names, False
-
-    # If indices is a List[Union[int, slice, Tensor, List[int], Tuple[int, ...]]] or a Tuple[Union[int, slice, Tensor,
-    # List[int], Tuple[int, ...]], ...], indexing is a number of indexing operations on different dimensions.
-    # import IPython; IPython.embed(using=False)
-    if is_indexing_multidimensional(indices):
-        # We need to replace Ellipsis with the equivalent number of single-dim slices because it can be used to index
-        # multiple dimensions depending on the structure of the other indices.
-        # indices = expand_indices(indices, len(names))
+    # If indices is a Sequence[IndexingType], indexing is a number of indexing operations on different dimensions, i.e.
+    # multidimensional indexing.
+    if isinstance(indices, Sequence):
+        # We need to replace any Ellipsis with the equivalent number of single-dim slices because it can be used to
+        # index multiple dimensions depending on the structure of the other indices.
         indices = replace_ellipsis(indices, len(names))
 
-        affected_dims = []
-        new_names = []
+        # Recursively determine the dimensions affected by each index.
+        affected_dims, new_names = [], []
         for i, index in enumerate(indices):
-            _, dims, nms, _ = determine_dims_affected_by_indexing(names, index, recursive_dim=i)
-            affected_dims.append(dims)
-            new_names.extend(nms)
+            description = determine_dims_affected_by_indexing(names, index, recursive_dim=i)
+            affected_dims.append(description.affected_dimensions)
+            new_names.extend(description.updated_dimension_names)
 
-        # Some dimensions may not have been affected by any of the indices. In that case, we need to add their names
-        # to the new names list. We can do this by adding names from the end of the original names list.
-        num_missing = len(names) - len(indices)
+        # Some trailing dimensions may not have been affected by any of the indices. In that case, we need to add
+        # their names to the new names list. We can do this by adding names from the end of the original names list.
+        num_missing = len(names) - number_of_indexed_dimensions(indices)
         if isinstance(indices[-1], torch.BoolTensor):
             num_missing -= indices[-1].ndim - 1  # BoolTensors affect `ndim` dimensions.
 
         if num_missing > 0:
             new_names.extend(names[-num_missing:])
 
-        return indices, affected_dims, new_names, True
+        return IndexingDescription(indices, affected_dims, new_names, True)
 
     err_msg = f"Indexing with {indices} is not supported. If you think this is a bug, please open an issue on GitHub."
     raise NotImplementedError(err_msg)
@@ -445,9 +451,7 @@ def any_along_dims(tensor: Tensor, dims: List[int]) -> Tensor:
 
 
 @implements(torch.Tensor.__getitem__)
-def __getitem__(
-    self: StreamTensor, indices: Union[None, int, slice, Tensor, List[Any], Tuple[Any, ...]]
-) -> StreamTensor:
+def __getitem__(self: StreamTensor, indices: Union[IndexingType, Sequence[IndexingType]]) -> StreamTensor:
     """Index a StreamTensor along any of its dimensions.
 
     If the indexing operation does not affect the batch or length dimensions it is done as usual and the resulting
@@ -483,35 +487,33 @@ def __getitem__(
 
     indexed_tensor = tensor[indices]
 
-    expanded_indices, affected_dims, names, is_multidim_indexing = determine_dims_affected_by_indexing(names, indices)
+    indices, affected_dims, new_names, is_multidim_indexing = determine_dims_affected_by_indexing(names, indices)
 
     if is_multidim_indexing:
         dims_affected_flat = [dim for dims in affected_dims for dim in dims]
     else:
         dims_affected_flat = affected_dims
         affected_dims = [affected_dims]
-        expanded_indices = [expanded_indices]
+        indices = [indices]
 
-    batch_dim = self.batch_dim
-    length_dim = self.length_dim
+    batch_dim = names.index(BATCH)
+    length_dim = names.index(LENGTH)
     is_batch_dim_affected = any([dim == batch_dim for dim in dims_affected_flat])
     is_length_dim_affected = any([dim == length_dim for dim in dims_affected_flat])
 
     if not (is_batch_dim_affected or is_length_dim_affected):
         # Indexing operation does not affect the batch or length dimensions, return the indexed tensor with same meta.
-        return StreamTensor(indexed_tensor.refine_names(*names), meta.clone())
+        return StreamTensor(indexed_tensor.refine_names(*new_names), meta.clone())
 
     # Placeholder variables for the indices that affect the batch and/or length dimensions.
-    batch_length_index = None
     batch_index = None
     length_index = None
 
-    # Handle multidimensional boolean tensor indexing
-    multidim_booltensor_locations = get_locations_of_multidimensional_booltensors(expanded_indices)
+    # Get the batch and length index if indexed with a multidimensional BoolTensor.
+    multidim_booltensor_locations = get_locations_of_multidimensional_booltensors(indices)
     if multidim_booltensor_locations:
         dims_and_indices = (
-            (tensor_loc, affected_dims[tensor_loc], expanded_indices[tensor_loc])
-            for tensor_loc in multidim_booltensor_locations
+            (tensor_loc, affected_dims[tensor_loc], indices[tensor_loc]) for tensor_loc in multidim_booltensor_locations
         )  # Keep only multidimensional tensors that affect batch and/or length.
 
         for tensor_loc, dims, tensor_index in dims_and_indices:
@@ -526,38 +528,25 @@ def __getitem__(
                     non_length_dims = [dim - tensor_loc for dim in dims if dim != length_dim]
                     length_index = any_along_dims(tensor_index, non_length_dims)
 
-                # TODO (JDH): Simplify the batch+length case, no need for actually computing the index. Just a flag will do.
-                case (True, True) if tensor_index.ndim > 2:
-                    # Reduce with any along all dimensions except the batch and length dimensions.
-                    non_batch_length_dims = [dim - tensor_loc for dim in dims if dim not in (batch_dim, length_dim)]
-                    batch_length_index = any_along_dims(tensor_index, non_batch_length_dims)
-                    break  # Found a 2D BoolTensor index on batch and length so remaining indices cannot affect them.
-
-                case _:  # (True, True) if tensor_index.ndim == 2:
-                    batch_length_index = tensor_index  # No reduction needed, just use the tensor batch_length_index.
-                    break  # Found a 2D BoolTensor index on batch and length so remaining indices cannot affect them.
-
-        if batch_length_index is not None:
-            if batch_dim > length_dim:
-                batch_length_index = batch_length_index.T  # Transpose if length comes before batch
-
-            fallback_operation_warning(
-                operation="multidimensional boolean tensor indexing",
-                description="when the batch and length dimensions are affected by the indexing operation. "
-                "This would create a mismatch with the StreamMetadata",
-            )
-            return indexed_tensor
+                case (True, True):
+                    # Multidimensional BoolTensor indexing on batch and length dimensions triggers a fallback.
+                    fallback_operation_warning(
+                        operation="multidimensional boolean tensor indexing",
+                        description="when the batch and length dimensions are affected by the indexing operation. "
+                        "This would create a mismatch with the StreamMetadata",
+                    )
+                    return indexed_tensor
 
     # Handle any other indexing operation
     if length_index is None and is_length_dim_affected:
         # Get the index that was used along the length dimension of the tensor.
-        length_index = expanded_indices[length_dim] if is_multidim_indexing else expanded_indices[0]
+        length_index = indices[length_dim] if is_multidim_indexing else indices[0]
 
     if batch_index is None and is_batch_dim_affected:
         # Get the index that was used along the batch dimension of the tensor.
-        batch_index = expanded_indices[batch_dim] if is_multidim_indexing else expanded_indices[0]
+        batch_index = indices[batch_dim] if is_multidim_indexing else indices[0]
 
-    return StreamTensor(indexed_tensor.refine_names(*names), meta[batch_index, length_index])
+    return StreamTensor(indexed_tensor.refine_names(*new_names), meta[batch_index, length_index])
 
 
 # indexing, slicing, joining, mutating methods
@@ -706,6 +695,92 @@ def masked_select(input: StreamTensor, mask: Tensor, *, out: Optional[torch.Tens
     return out
 
 
+# @implements(torch.diagonal_scatter)
+# @implements(torch.select_scatter)
+# @implements(torch.slice_scatter)
+
+# X @implements(torch.scatter_add)
+# X @implements(torch.Tensor.scatter_add)
+# X @implements(torch.Tensor.scatter_add_)
+# X @implements(torch.scatter_reduce)
+# X @implements(torch.Tensor.scatter_reduce)
+# X @implements(torch.Tensor.scatter_reduce_)
+
+
+@implements(torch.scatter_add)
+@implements(torch.Tensor.scatter_add)
+def scatter_add(
+    input: Tensor,
+    dim: int,
+    index: Tensor,
+    src: Union[Number, Tensor],
+    out: Optional[torch.Tensor] = None,
+) -> StreamTensor:
+    metas, names = [], []
+    input, index, src, out = decouple_recursive((input, index, src, out), metas, names)
+
+    out = torch.scatter_add(input, dim=dim, index=index, src=src, out=out)
+
+    # TODO (JDH): Is it necessary to fall back when the length dimension is reduced? Could we assume/enforce/set that
+    # StreamTensors without a length dimension have lengths 1?
+    if dim == names[0].index(BATCH) or dim == names[0].index(LENGTH):
+        fallback_operation_warning("scatter_add", "when applied on the batch or length dimensions")
+        return out
+
+    if not all(meta == metas[0] for meta in metas):
+        fallback_operation_warning(
+            "scatter_add", "when more than one of input, index and src are StreamTensor with different StreamMetadata"
+        )
+        return out
+
+    out.rename_(*names[0])
+    return StreamTensor(out, metas[0].clone())
+
+
+@implements(torch.Tensor.scatter_add_)
+def scatter_add_(input: StreamTensor, dim: int, index: Tensor, src: Union[Number, Tensor]) -> StreamTensor:
+    return scatter_add(input, dim=dim, index=index, src=src, out=input)
+
+
+@implements(torch.scatter_reduce)
+@implements(torch.Tensor.scatter_reduce)
+def scatter_reduce(
+    input: StreamTensor,
+    dim: int,
+    index: Tensor,
+    src: Tensor,
+    reduce: str,
+    *,
+    out: Optional[torch.Tensor] = None,
+    include_self: bool = True,
+) -> StreamTensor:
+    metas, names = [], []
+    input, index, src, out = decouple_recursive((input, index, src, out), metas, names)
+
+    out = torch.scatter_reduce(input, dim=dim, index=index, src=src, reduce=reduce, include_self=include_self, out=out)
+
+    if dim == names[0].index(BATCH) or dim == names[0].index(LENGTH):
+        fallback_operation_warning("scatter_reduce", "when applied on the batch or length dimensions")
+        return out
+
+    if not all(meta == metas[0] for meta in metas):
+        fallback_operation_warning(
+            "scatter_reduce",
+            "when more than one of input, index and src are StreamTensor with different StreamMetadata",
+        )
+        return out
+
+    out.rename_(*names[0])
+    return StreamTensor(out, metas[0].clone())
+
+
+@implements(torch.Tensor.scatter_reduce_)
+def scatter_reduce_(
+    input: StreamTensor, dim: int, index: Tensor, reduce: str, src: Tensor, include_self: bool = True
+) -> StreamTensor:
+    return scatter_reduce(input, dim=dim, index=index, src=src, reduce=reduce, out=input, include_self=include_self)
+
+
 @implements(torch.flatten)
 @implements(torch.Tensor.flatten)
 def flatten(input: StreamTensor, start_dim: int = 0, end_dim: int = -1) -> StreamTensor:
@@ -761,15 +836,15 @@ def unqsqueeze(input: StreamTensor, dim: int) -> StreamTensor:
 # X @implements(torch.gather)
 # X @implements(torch.narrow)
 
-# @implements(torch.scatter)
+# X @implements(torch.scatter)
 # @implements(torch.diagonal_scatter)
 # @implements(torch.select_scatter)
 # @implements(torch.slice_scatter)
 
-# @implements(torch.scatter_add)
-# @implements(torch.scatter_add_)
-# @implements(torch.scatter_reduce)
-# @implements(torch.scatter_reduce_)
+# X @implements(torch.scatter_add)
+# X @implements(torch.scatter_add_)
+# X @implements(torch.scatter_reduce)
+# X @implements(torch.scatter_reduce_)
 
 # X @implements(torch.select)  # Equivalent to slicing with torch.Tensor.__getitem__
 # X @implements(torch.select_copy)

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -360,7 +360,7 @@ def determine_dims_affected_by_indexing(
     if indices is None:
         updated_names = [None] if is_recursive else (None,) + names
         return IndexingDescription(indices, [], updated_names, False)
- 
+
     # If indices is slice(None), or Ellipsis no dimensions are affected.
     if indices == slice(None):
         updated_names = [names[first_dim]] if is_recursive else names

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -686,7 +686,7 @@ def select(input: StreamTensor, dim: int, index: Union[None, int, slice, Tensor,
     # TODO (JDH): Separate out torch.select and torch.Tensor.select which return views of the original data instead.
     dim = dim if dim >= 0 else input.ndim + dim
     getitem_index = (slice(None),) * dim + (index,)
-    return input[*getitem_index]
+    return input.__getitem__(*getitem_index)
 
 
 @implements(torch.masked_select)

--- a/dreamstream/overrides.py
+++ b/dreamstream/overrides.py
@@ -695,18 +695,6 @@ def masked_select(input: StreamTensor, mask: Tensor, *, out: Optional[torch.Tens
     return out
 
 
-# @implements(torch.diagonal_scatter)
-# @implements(torch.select_scatter)
-# @implements(torch.slice_scatter)
-
-# X @implements(torch.scatter_add)
-# X @implements(torch.Tensor.scatter_add)
-# X @implements(torch.Tensor.scatter_add_)
-# X @implements(torch.scatter_reduce)
-# X @implements(torch.Tensor.scatter_reduce)
-# X @implements(torch.Tensor.scatter_reduce_)
-
-
 @implements(torch.scatter_add)
 @implements(torch.Tensor.scatter_add)
 def scatter_add(

--- a/dreamstream/tensor.py
+++ b/dreamstream/tensor.py
@@ -269,9 +269,6 @@ class StreamMetadata:
         self, indices: Union[None, int, slice, List[Any], Tuple[Any, ...], torch.IntTensor, torch.BoolTensor]
     ) -> "StreamMetadata":
         """Index the metadata along the batch and/or length dimensions."""
-        # import IPython
-        # IPython.embed(using=False, header="index")
-
         match indices:
             case None:
                 return self  # TODO (JDH): Should we return a copy instead?
@@ -295,8 +292,8 @@ class StreamMetadata:
     def index_batch(
         self, indices: Union[None, int, slice, List[int], Tuple[int, ...], torch.IntTensor, torch.BoolTensor]
     ) -> "StreamMetadata":
-        """Return a StreamMetadata object with the specified batch indices. Also supports 2-dimension bool tensors for
-        ."""
+        """Return a StreamMetadata object with the specified batch indices."""
+        # TODO (JDH): Implement using match statement instead of if/else.
         if indices is None:
             return self  # TODO (JDH): Should we return a copy instead?
 
@@ -348,6 +345,7 @@ class StreamMetadata:
                 raise IndexError(f"Indexing length with {indices} is not supported.")
 
     def index_batch_and_length(self, indices: torch.BoolTensor) -> "StreamMetadata":
+        """Return a StreamMetadata object with the batch and length indexed with a single 2D BoolTensor."""
         if isinstance(indices, torch.Tensor) and indices.ndim > 2:
             raise ValueError(f"Expected indices to be a 2-dimensional tensor, but got {indices.ndim} dimensions.")
 

--- a/dreamstream/tensor.py
+++ b/dreamstream/tensor.py
@@ -2,7 +2,7 @@ import itertools
 import warnings
 
 from copy import deepcopy
-from typing import Any, Callable, List, Tuple, Union
+from typing import Any, Callable, List, Optional, Tuple, Union, Mapping, Sequence
 
 import torch
 import numpy as np
@@ -25,17 +25,40 @@ from dreamstream.utils.numba import (
 # they are needed. This minimizes overhead computation on StreamTensors that end up as leaf nodes in the graph.
 
 
-def decouple(func, tensor, *args, **kwargs):
+def decouple_recursive(x, metas: Optional[List["StreamMetadata"]] = None, names: Optional[List[str]] = None):
+    """Recurse a nested structure and decouple all StreamTensors."""
+    if isinstance(x, StreamTensor):
+        if metas is None and names is None:
+            return x.tensor()
+
+        tensor, meta, name = x.decouple()
+        metas.append(meta)
+        names.append(name)
+        return tensor
+
+    elif isinstance(x, Mapping):
+        return type(x)((k, decouple_recursive(v, metas=metas, names=names)) for k, v in x.items())
+    elif isinstance(x, Sequence):
+        return type(x)(decouple_recursive(v, metas=metas, names=names) for v in x)
+
+    return x
+
+
+def decouple(func, *args, **kwargs):
     """Call function on tensor after decoupling it from StreamMetadata."""
-    return func(tensor.tensor(), *args, **kwargs)
+    args, kwargs = decouple_recursive((args, kwargs))
+    return func(*args, **kwargs)
 
 
-def recouple(func, tensor, *args, **kwargs):
+def recouple(func, *args, **kwargs):
     """Call function on tensor after recoupling it to StreamMetadata and recouple again afterwards."""
-    tensor, meta, names = tensor.decouple()
-    tensor = func(tensor, *args, **kwargs)
-    tensor.rename_(*names)
-    return as_stream_tensor(data=tensor, meta=meta, names=names)
+    metas, names = [], []
+    args, kwargs = decouple_recursive((args, kwargs), metas=metas, names=names)
+    if not all(metas[0] == m for m in metas):
+        raise ValueError("All StreamTensors must have the same StreamMetadata.")
+
+    tensor = func(*args, **kwargs)
+    return as_stream_tensor(data=tensor, meta=metas[0], names=names[0])
 
 
 class StreamMetadata:
@@ -220,7 +243,14 @@ class StreamMetadata:
 
     def __copy__(self):
         """Returns a deep of the StreamMetadata object because we don't support shallow copies."""
-        return self.__deepcopy__()
+        new_meta = StreamMetadata(
+            ids=self.ids,
+            sos=self.sos,
+            eos=self.eos,
+            lengths=self.lengths,
+        )
+        new_meta.__dict__.update(self.__dict__)
+        return new_meta
 
     def __deepcopy__(self):
         """Return a deep copy of the StreamMetadata object."""
@@ -292,24 +322,24 @@ class StreamMetadata:
     ) -> "StreamMetadata":
         """Index the metadata along the batch and/or length dimensions."""
         match indices:
-            case None:
-                return self.__deepcopy__()
             case list() | tuple() if not all(isinstance(i, (int, bool)) for i in indices):
                 match indices:
-                    case (None, None):
-                        return self.__deepcopy__()
                     case (batch_indices, None):
                         return self.index_batch(batch_indices)
                     case (None, length_indices):
                         return self.index_length(length_indices)
                     case (batch_indices, length_indices):
                         return self.index_batch(batch_indices).index_length(length_indices)
+                    case (None, None):
+                        return self.__deepcopy__()
             case torch.BoolTensor() if indices.ndim > 1:
                 return self.index_batch_and_length(indices)
             case torch.Tensor() | int() | slice() | list():
                 return self.index_batch(indices)
             case tuple() if len(indices) == 2:
                 return self.index_batch(indices[0]).index_length(indices[1])
+            case None:
+                return self.__deepcopy__()
             case _:
                 raise TypeError(f"Unsupported index type: {type(indices)}")
 
@@ -379,22 +409,33 @@ class StreamMetadata:
         if not keep_ids.any():
             return StreamMetadata([], torch.tensor([]), torch.tensor([]), torch.tensor([]))
 
+        broadcast_batch = indices.size(0) == 1 and len(self.ids) > 1
+        broadcast_length = indices.size(1) == 1 and self.max_length > 1
+        if broadcast_batch and broadcast_length:
+            return self.__deepcopy__()
+
         if not keep_ids.all():
             ids = [id for i, id in enumerate(self.ids) if keep_ids[i]]
             sos = self.sos[keep_ids]
             eos = self.eos[keep_ids]
             lengths = self.lengths[keep_ids]
             indices = indices[keep_ids]
-        else:
+        else:  # includes `broadcast_batch == True`
             ids = deepcopy(self.ids)
             sos = self.sos
             eos = self.eos
             lengths = self.lengths
 
-        new_lengths = cumsum[keep_ids, lengths - 1]
         sos = sos & indices[:, 0]  # SOS only if the first index is included.
-        eos = eos & indices[range(indices.size(0)), lengths - 1]  # EOS only if the last non-padding index is included.
-        return StreamMetadata(ids, sos, eos, new_lengths)
+        if not broadcast_length:
+            # EOS if any index at or beyond the last non-padding index is included.
+            start = cumsum[keep_ids, 0]
+            stop = indices.size(-1) - torch.fliplr(indices).to(torch.float32).argmax(-1)
+            eos = eos & (start < lengths) & (lengths <= stop)
+            # eos = eos & indices[range(indices.size(0)), lengths - 1]  # EOS only if the last non-padding is included.
+            lengths = cumsum[keep_ids, lengths - 1]
+
+        return StreamMetadata(ids, sos, eos, lengths)
 
     def _index_length_int(self, index: int) -> "StreamMetadata":
         # Convert negative indices to positive
@@ -444,7 +485,8 @@ class StreamMetadata:
         min_i, max_i = minmax(indices_np)
         lengths = update_lengths_from_list_of_indices(lengths_np, indices_np)
         sos = self.sos.clone() if min_i == 0 else torch.zeros_like(self.sos)
-        eos = torch.from_numpy(update_eos_from_integer(self.eos.numpy(), lengths_np, max_i - 1))
+        eos = torch.from_numpy(update_eos_from_slice(self.eos.numpy(), lengths_np, min_i, max_i))
+        # TODO (JDH): Keep EOS true if the indexing spans over the last non-padding element.
         return StreamMetadata(deepcopy(self.ids), sos, eos, lengths)
 
     def _index_length_1d_tensor(self, indices: torch.Tensor) -> "StreamMetadata":
@@ -571,7 +613,7 @@ class StreamMetadata:
             end = np.cumsum(split_size_or_sections)
             start = np.concatenate(([0], end[:-1]))
 
-        return [self[:, i:j] for i, j in zip(start, end)]
+        return [self.index_length(slice(i, j)) for i, j in zip(start, end)]
 
     def unbind_batch(self) -> List["StreamMetadata"]:
         """Split a StreamMetadata object into a list of StreamMetadata objects along the batch dimension.
@@ -587,7 +629,7 @@ class StreamMetadata:
 
     def clone(self) -> "StreamMetadata":
         """Return a deep copy of the StreamMetadata object."""
-        return self.__copy__()
+        return self.__deepcopy__()
 
     def size(self) -> int:
         """Return the size of the StreamMetadata object. Same as len()."""

--- a/dreamstream/tensor.py
+++ b/dreamstream/tensor.py
@@ -479,7 +479,7 @@ class StreamMetadata:
 
         # Raise error if the indices are not sorted
         if not is_sorted_ascending(indices_np):
-            raise RuntimeError("Indices must be sorted when indexing length with lists or tuples.")
+            raise IndexError("Indices must be sorted when indexing length with lists or tuples.")
 
         # Update lengths, sos, and eos
         min_i, max_i = minmax(indices_np)

--- a/dreamstream/tensor.py
+++ b/dreamstream/tensor.py
@@ -714,7 +714,8 @@ class StreamTensor(torch.Tensor):
 
         # Unhandled functions are passed to the torch.Tensor.__torch_function__ method.
         warnings.warn(
-            f"Function {func.__name__} is not handled by StreamTensor.__torch_function__ and may not work as expected."
+            f"Function `{func.__name__}` is not handled by `StreamTensor.__torch_function__` "
+            "and may not work as expected."
         )
         out = super().__torch_function__(func, types, args, kwargs)
 

--- a/dreamstream/utils/numba.py
+++ b/dreamstream/utils/numba.py
@@ -46,16 +46,6 @@ def make_indices_positive_(array, max_length: int) -> None:
 
 
 @numba.jit(nopython=True)
-def broadcasted_leq_sum(array1, array2) -> np.ndarray:
-    """Return a 1D array of the number of elements in array1 that are less than or equal to each element in array2.
-
-    This is more than 10x faster than the equivalent torch version on CPU:
-    > (self.lengths.unsqueeze(0) <= indices_t.unsqueeze(1)).sum(dim=0)
-    """
-    return np.sum(np.expand_dims(array1, axis=0) <= np.expand_dims(array2, axis=1), axis=0)
-
-
-@numba.jit(nopython=True)
 def update_lengths_from_list_of_indices(lengths, indices) -> None:
     """For each element in lengths, return the number of elements in indices that are less than that element.
 

--- a/dreamstream/utils/numba.py
+++ b/dreamstream/utils/numba.py
@@ -77,3 +77,8 @@ def update_eos_from_integer(eos: np.ndarray, lengths: np.ndarray, index: int) ->
     This is 2x faster than the non-compiled torch method on CPU: `(eos & (lengths <= index + 1))`.
     """
     return eos & (lengths <= index + 1)  # TODO (JDH): Would `self.lengths < indices` be better?
+
+
+@numba.jit(nopython=True)
+def update_eos_from_slice(eos: np.ndarray, lengths: np.ndarray, start: int, stop: int) -> None:
+    return eos & (start < lengths) & (lengths <= stop)

--- a/dreamstream/warnings.py
+++ b/dreamstream/warnings.py
@@ -1,0 +1,31 @@
+
+import warnings
+
+
+class TorchStreamWarning(RuntimeWarning):
+    pass
+
+
+class TorchStreamFallbackWarning(TorchStreamWarning):
+    pass
+
+
+FALLBACK_WARNING = "The `{operation}` operation is not supported for `StreamTensors`{description}. " \
+                   "Instead, the `{operation}` operation will return a regular `torch.Tensor` and subsequent " \
+                   "operations will be performed without the use of the torchstream functionality. If this was " \
+                   "expected, you can suppress this warning by calling `torchstream.suppress_warnings(True)` or by " \
+                   "converting your input StreamTensor(s) to regular `torch.Tensors` manually before the call " \
+                   "to `{operation}`. If this was unexpected it might have lead to an error being raised and " \
+                   "might indicate an error in your code. Otherwise, please open an issue on GitHub." \
+
+
+REASON_METADATA_AMBIGUOUS = "since combining the StreamMetadata of the inputs is ambiguous"
+
+
+def fallback_operation_warning(operation: str, description: str = ""):
+    warnings.warn(FALLBACK_WARNING.format(operation=operation, description=description), TorchStreamFallbackWarning, stacklevel=2)
+
+
+def suppress_warnings(suppress: bool = True):
+    """Enable or disable warnings about fallback to regular torch operations."""
+    warnings.simplefilter("ignore" if suppress else "default", TorchStreamWarning)

--- a/dreamstream/warnings.py
+++ b/dreamstream/warnings.py
@@ -1,4 +1,3 @@
-
 import warnings
 
 
@@ -10,22 +9,26 @@ class TorchStreamFallbackWarning(TorchStreamWarning):
     pass
 
 
-FALLBACK_WARNING = "The `{operation}` operation is not supported for `StreamTensors`{description}. " \
-                   "Instead, the `{operation}` operation will return a regular `torch.Tensor` and subsequent " \
-                   "operations will be performed without the use of the torchstream functionality. If this was " \
-                   "expected, you can suppress this warning by calling `torchstream.suppress_warnings(True)` or by " \
-                   "converting your input StreamTensor(s) to regular `torch.Tensors` manually before the call " \
-                   "to `{operation}`. If this was unexpected it might have lead to an error being raised and " \
-                   "might indicate an error in your code. Otherwise, please open an issue on GitHub." \
-
+FALLBACK_WARNING = (
+    "The `{operation}` operation is not supported for `StreamTensors`{description}. "
+    "Instead, the `{operation}` operation will return a regular `torch.Tensor` and subsequent "
+    "operations will be performed without the use of the torchstream functionality. If this was "
+    "expected, you can suppress this warning by calling `torchstream.suppress_warnings(True)` or by "
+    "converting your input StreamTensor(s) to regular `torch.Tensors` manually before the call "
+    "to `{operation}`. If this was unexpected it might have lead to an error being raised and "
+    "might indicate an error in your code. Otherwise, please open an issue on GitHub."
+)
 
 REASON_METADATA_AMBIGUOUS = "since combining the StreamMetadata of the inputs is ambiguous"
 
 
 def fallback_operation_warning(operation: str, description: str = ""):
-    warnings.warn(FALLBACK_WARNING.format(operation=operation, description=description), TorchStreamFallbackWarning, stacklevel=2)
+    warnings.warn(
+        FALLBACK_WARNING.format(operation=operation, description=description), TorchStreamFallbackWarning, stacklevel=2
+    )
 
 
+# TODO (JDH): Add a test for this function
 def suppress_warnings(suppress: bool = True):
     """Enable or disable warnings about fallback to regular torch operations."""
     warnings.simplefilter("ignore" if suppress else "default", TorchStreamWarning)

--- a/dreamstream/warnings.py
+++ b/dreamstream/warnings.py
@@ -14,9 +14,10 @@ FALLBACK_WARNING = (
     "Instead, the `{operation}` operation will return a regular `torch.Tensor` and subsequent "
     "operations will be performed without the use of the torchstream functionality. If this was "
     "expected, you can suppress this warning by calling `torchstream.suppress_warnings(True)` or by "
-    "converting your input StreamTensor(s) to regular `torch.Tensors` manually before the call "
-    "to `{operation}`. If this was unexpected it might have lead to an error being raised and "
-    "might indicate an error in your code. Otherwise, please open an issue on GitHub."
+    "converting your input StreamTensor(s) to regular `torch.Tensors` manually before passing them to "
+    "the `{operation}` operation. If this was unexpected it might have lead to an error being raised and "
+    "might indicate an error in your code. If you got an error and think it's a bug in TorchStream, please "
+    "open an issue on GitHub."
 )
 
 REASON_METADATA_AMBIGUOUS = "since combining the StreamMetadata of the inputs is ambiguous"
@@ -24,7 +25,9 @@ REASON_METADATA_AMBIGUOUS = "since combining the StreamMetadata of the inputs is
 
 def fallback_operation_warning(operation: str, description: str = ""):
     warnings.warn(
-        FALLBACK_WARNING.format(operation=operation, description=description), TorchStreamFallbackWarning, stacklevel=2
+        FALLBACK_WARNING.format(operation=operation, description=" " + description if description else ""),
+        TorchStreamFallbackWarning,
+        stacklevel=2,
     )
 
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,5 +1,3 @@
-from typing import Mapping, Sequence
-
 import pytest
 import torch
 

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -309,7 +309,7 @@ class TestTakeAlongDim:
 
     def test_take_along_feature_truncated(self, stream_tensor_3d_fixture):
         with pytest.raises(RuntimeError):
-            s = stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.truncated_index)
+            stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.truncated_index)
 
     def test_take_along_length(self, stream_tensor_3d_fixture):
         with pytest.raises(IndexError):
@@ -506,24 +506,28 @@ class TestUnsqueeze:
 
 
 class TestSqueeze:
-    # def test_squeeze_non_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-    #     stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
-    #     assert_on_indexing_op(
-    #         stream_tensor_3d_fixture,
-    #         torch.squeeze,
-    #         dim=0,
-    #         **stream_meta_kwargs_fixture,
-    #     )
+    def test_squeeze_non_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.squeeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
 
-    # def test_squeeze_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-    #     s = as_stream_tensor(stream_tensor_3d_fixture.tensor().sum(dim=1, keepdim=True), names=stream_tensor_3d_fixture.names, meta=stream_tensor_3d_fixture.meta)
-    #     stream_meta_kwargs_fixture["names"] = (BATCH, LENGTH)
-    #     assert_on_indexing_op(
-    #         s,
-    #         torch.squeeze,
-    #         dim=1,
-    #         **stream_meta_kwargs_fixture,
-    #     )
+    def test_squeeze_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        s = as_stream_tensor(
+            stream_tensor_3d_fixture.tensor().sum(dim=1, keepdim=True),
+            names=stream_tensor_3d_fixture.names,
+            meta=stream_tensor_3d_fixture.meta,
+        )
+        stream_meta_kwargs_fixture["names"] = (BATCH, LENGTH)
+        assert_on_indexing_op(
+            s,
+            torch.squeeze,
+            dim=1,
+            **stream_meta_kwargs_fixture,
+        )
 
     def test_squeeze_all_singleton_dims(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
         names = (None, None) + stream_tensor_3d_fixture.names

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,11 +1,9 @@
-import pytest
+from typing import Mapping, Sequence
 
+import pytest
 import torch
 
-# TODO (JDH): Tests will fail if we don't also import this, since nothing gets overridden.
-import dreamstream.overrides  # noqa: F401
-
-from dreamstream.tensor import StreamTensor, stream_tensor, stream_metadata, LENGTH, BATCH
+from dreamstream.tensor import StreamTensor, as_stream_tensor, stream_tensor, stream_metadata, LENGTH, BATCH
 from dreamstream.func_coverage import (
     DECOUPLE_FUNCTIONS,
     FLAT_OVERRIDABLE_FUNCTIONS,
@@ -14,19 +12,32 @@ from dreamstream.func_coverage import (
     UNSUPPORTED_FUNCTIONS,
     VALID_FUNCTIONS,
 )
+from dreamstream.overrides import join_dim_names
+
+
+def test_meta_kwargs():
+    return dict(
+        ids=["first", "middle", "last"],
+        sos=[True, False, False],
+        eos=[False, False, True],
+        lengths=[3, 3, 2],
+    )
 
 
 @pytest.fixture()
+def stream_meta_kwargs_fixture():
+    return test_meta_kwargs()
+
+
 def stream_tensor_3d():
-    meta = stream_metadata(
-        ids=["first", "middle", "last"], sos=[True, False, False], eos=[False, False, True], lengths=[3, 3, 2]
-    )
-    tensor = stream_tensor(
-        [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]], [[13, 14, 15], [16, 17, 18]]],
-        meta,
-        names=(BATCH, "F", LENGTH),
-    )  # (batch, feature, length) = (3, 2, 3)
-    return tensor
+    test_meta = stream_metadata(**test_meta_kwargs())
+    test_tensor_data = [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]], [[13, 14, 15], [16, 17, 18]]]
+    return stream_tensor(test_tensor_data, test_meta, names=(BATCH, "F", LENGTH))  # (3, 2, 3)
+
+
+@pytest.fixture()
+def stream_tensor_3d_fixture():
+    return stream_tensor_3d()
 
 
 ## Instantiation
@@ -53,38 +64,59 @@ def test_instantiate_stream_tensor(data):
 
 ## Valid, coupled and recoupled functions, unsupported functions and function coverage
 
-TEST_KWARGS_VALID_FUNCTIONS = {
-    torch.Tensor.__repr__: dict(),
+
+class Inputs:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+    def __iter__(self):
+        return iter((self.args, self.kwargs))
+
+
+def to_torch_tensor_recursive(x):
+    if isinstance(x, StreamTensor):
+        return x.tensor()
+    elif isinstance(x, Sequence):
+        return type(x)(to_torch_tensor_recursive(xi) for xi in x)
+    elif isinstance(x, Mapping):
+        return type(x)((k, to_torch_tensor_recursive(v)) for k, v in x.items())
+    return x
+
+
+TEST_INPUTS_VALID_FUNCTIONS = {
+    torch.Tensor.__repr__: Inputs(stream_tensor_3d()),
 }
 
-TEST_KWARGS_DECOUPLE_FUNCTIONS = {
-    torch.argmax: dict(dim=-1),
-    torch.argmin: dict(dim=-1),
-    torch.argsort: dict(dim=-1),
+TEST_INPUTS_DECOUPLE_FUNCTIONS = {
+    torch.argmax: Inputs(stream_tensor_3d(), dim=-1),
+    torch.argmin: Inputs(stream_tensor_3d(), dim=-1),
+    torch.argsort: Inputs(stream_tensor_3d(), dim=-1),
 }
 
-TEST_KWARGS_RECOUPLE_FUNCTIONS = {
-    torch.adjoint: dict(),
-    torch.sigmoid: dict(),
-    torch.Tensor.sigmoid: dict(),
-    torch.transpose: dict(dim0=0, dim1=1),
+TEST_INPUTS_RECOUPLE_FUNCTIONS = {
+    torch.adjoint: Inputs(stream_tensor_3d()),
+    torch.sigmoid: Inputs(stream_tensor_3d()),
+    torch.Tensor.sigmoid: Inputs(stream_tensor_3d()),
+    torch.transpose: Inputs(stream_tensor_3d(), dim0=0, dim1=1),
+    torch.where: Inputs(stream_tensor_3d() > 5, input=stream_tensor_3d() - 1, other=stream_tensor_3d()),
+    torch.where: Inputs(stream_tensor_3d() > 5, input=stream_tensor_3d() - 1, other=2),
+    torch.Tensor.where: Inputs(stream_tensor_3d(), condition=stream_tensor_3d() > 5, other=stream_tensor_3d()),
 }
 
 TEST_SKIP_EQUALITY_CHECK = {torch.Tensor.__repr__}
 
 
-def test_valid_coupled_recoupled_functions(stream_tensor_3d):
+def test_valid_coupled_recoupled_functions():
+    """Iterate over all valid, coupled and recoupled functions and check that they work as expected."""
     FUNCTIONS = VALID_FUNCTIONS | DECOUPLE_FUNCTIONS | RECOUPLE_FUNCTIONS
-    KWARGS = TEST_KWARGS_VALID_FUNCTIONS | TEST_KWARGS_DECOUPLE_FUNCTIONS | TEST_KWARGS_RECOUPLE_FUNCTIONS
-
-    assert len(FUNCTIONS) == len(KWARGS), "The number of functions and test arguments must match."
+    INPUTS = TEST_INPUTS_VALID_FUNCTIONS | TEST_INPUTS_DECOUPLE_FUNCTIONS | TEST_INPUTS_RECOUPLE_FUNCTIONS
 
     failed = []
-    for f in FUNCTIONS:
+    for f, (args, kwargs) in INPUTS.items():
         try:
-            kwargs = KWARGS[f]
-            stream_tensor_out = f(stream_tensor_3d, **kwargs)
-            torch_tensor_out = f(stream_tensor_3d.tensor(), **kwargs)
+            stream_tensor_out = f(*args, **kwargs)
+            torch_tensor_out = f(*to_torch_tensor_recursive(args), **to_torch_tensor_recursive(kwargs))
 
             if f in TEST_SKIP_EQUALITY_CHECK:
                 continue
@@ -99,16 +131,25 @@ def test_valid_coupled_recoupled_functions(stream_tensor_3d):
         except Exception as e:
             failed.append((f, e))
 
+    err = ""
     if any(failed):
-        failed_str = "\n\n".join([f"{f.__name__}: {e}" for f, e in failed])
-        raise AssertionError(f"The following functions claimed to be valid, were not:\n{failed_str}")
+        failed_str = " - " + "\n\n - ".join([f"{f.__name__}: {e}" for f, e in failed])
+        err += f"The following functions claimed to be valid, were not:\n{failed_str}"
+
+    untested_functions = FUNCTIONS - set(INPUTS.keys())
+    if untested_functions:
+        untested_str = " - " + "\n - ".join([f.__name__ for f in untested_functions])
+        err += f"\n\nThe following functions were not tested:\n{untested_str}"
+
+    if err:
+        raise AssertionError("\n\n" + err)
 
 
-# def test_unsupported_functions(stream_tensor_3d):
+# def test_unsupported_functions(stream_tensor_3d_fixture):
 #     failed = []
 #     for f in UNSUPPORTED_FUNCTIONS:
 #         try:
-#             f(stream_tensor_3d)
+#             f(stream_tensor_3d_fixture)
 #         except Exception as e:
 #             failed.append((f, e))
 
@@ -134,32 +175,52 @@ def test_function_coverage():
 ## Indexing functions
 
 
-class TestNarrow:
-    def test_narrow_batch(self, stream_tensor_3d):
-        """Test `torch.narrow` on a StreamTensor when applied to batch, length, and feature dimensions."""
-        s = stream_tensor_3d.narrow(dim=0, start=1, length=2)
-        assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().narrow(dim=0, start=1, length=2))
-        assert s.meta.ids == ["middle", "last"]
-        assert torch.equal(s.meta.sos, torch.tensor([False, False]))
-        assert torch.equal(s.meta.eos, torch.tensor([False, True]))
-        assert torch.equal(s.meta.lengths, torch.tensor([3, 2]))
-        assert s.names == (BATCH, "F", LENGTH)
+def assert_on_indexing_op(stream_tensor, func, *args, ids, lengths, sos, eos, names, **kwargs):
+    # TODO (JDH): Use this method for all indexing tests to reduce verbosity.
+    s = func(stream_tensor, *args, **kwargs)
+    t = func(stream_tensor.tensor(), *args, **kwargs)
+    assert isinstance(s, StreamTensor)
+    assert torch.equal(s.tensor(), t)
+    assert s.meta.ids == ids
+    assert torch.equal(s.meta.sos, torch.tensor(sos))
+    assert torch.equal(s.meta.eos, torch.tensor(eos))
+    assert torch.equal(s.meta.lengths, torch.tensor(lengths))
+    assert s.names == names
 
-    def test_narrow_feature(self, stream_tensor_3d):
-        s = stream_tensor_3d.narrow(dim=1, start=1, length=1)
+
+class TestNarrow:
+    def test_narrow_batch(self, stream_tensor_3d_fixture):
+        """Test `torch.narrow` on a StreamTensor when applied to batch, length, and feature dimensions."""
+        assert_kwargs = dict(
+            ids=["middle", "last"],
+            lengths=[3, 2],
+            sos=[False, False],
+            eos=[False, True],
+            names=(BATCH, "F", LENGTH),
+        )
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.narrow,
+            dim=0,
+            start=1,
+            length=2,
+            **assert_kwargs,
+        )
+
+    def test_narrow_feature(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.narrow(dim=1, start=1, length=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().narrow(dim=1, start=1, length=1))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().narrow(dim=1, start=1, length=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_narrow_length(self, stream_tensor_3d):
-        s = stream_tensor_3d.narrow(dim=2, start=1, length=2)
+    def test_narrow_length(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.narrow(dim=2, start=1, length=2)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().narrow(dim=2, start=1, length=2))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().narrow(dim=2, start=1, length=2))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([False, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
@@ -198,62 +259,89 @@ class TestGather:
         ]
     )
 
-    def test_gather_batch(self, stream_tensor_3d):
+    def test_gather_batch(self, stream_tensor_3d_fixture):
         """Test `torch.gather` on a StreamTensor when applied to batch, length, and feature dimensions."""
         with pytest.raises(IndexError):
-            stream_tensor_3d.gather(dim=0, index=self.full_index)
+            stream_tensor_3d_fixture.gather(dim=0, index=self.full_index)
 
-    def test_gather_feature(self, stream_tensor_3d):
-        s = stream_tensor_3d.gather(dim=1, index=self.full_index)
+    def test_gather_feature(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.gather(dim=1, index=self.full_index)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().gather(dim=1, index=self.full_index))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().gather(dim=1, index=self.full_index))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_gather_feature_truncated(self, stream_tensor_3d):
-        s = stream_tensor_3d.gather(dim=1, index=self.truncated_index)
+    def test_gather_feature_truncated(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.gather(dim=1, index=self.truncated_index)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().gather(dim=1, index=self.truncated_index))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().gather(dim=1, index=self.truncated_index))
         assert s.meta.ids == ["first", "middle"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False]))
         assert torch.equal(s.meta.lengths, torch.tensor([2, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_gather_length(self, stream_tensor_3d):
+    def test_gather_length(self, stream_tensor_3d_fixture):
         with pytest.raises(IndexError):
-            stream_tensor_3d.gather(dim=2, index=self.full_index)
+            stream_tensor_3d_fixture.gather(dim=2, index=self.full_index)
+
+
+class TestTakeAlongDim:
+    def test_take_along_batch(self, stream_tensor_3d_fixture):
+        """Test `torch.take_along_dim` on a StreamTensor when applied to batch, length, and feature dimensions."""
+        with pytest.raises(IndexError):
+            stream_tensor_3d_fixture.take_along_dim(dim=0, indices=TestGather.full_index)
+
+    def test_take_along_feature(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.full_index)
+        assert isinstance(s, StreamTensor)
+        assert torch.equal(
+            s.tensor(), stream_tensor_3d_fixture.tensor().take_along_dim(dim=1, indices=TestGather.full_index)
+        )
+        assert s.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
+        assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
+        assert s.names == (BATCH, "F", LENGTH)
+
+    def test_take_along_feature_truncated(self, stream_tensor_3d_fixture):
+        with pytest.raises(RuntimeError):
+            s = stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.truncated_index)
+
+    def test_take_along_length(self, stream_tensor_3d_fixture):
+        with pytest.raises(IndexError):
+            stream_tensor_3d_fixture.take_along_dim(dim=2, indices=TestGather.full_index)
 
 
 class TestSelect:
-    def test_select_batch(self, stream_tensor_3d):
+    def test_select_batch(self, stream_tensor_3d_fixture):
         """Test `torch.select` on a StreamTensor when applied to batch, length, and feature dimensions."""
-        s = stream_tensor_3d.select(dim=0, index=1)
+        s = stream_tensor_3d_fixture.select(dim=0, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().select(dim=0, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=0, index=1))
         assert s.meta.ids == ["middle"]
         assert torch.equal(s.meta.sos, torch.tensor([False]))
         assert torch.equal(s.meta.eos, torch.tensor([False]))
         assert torch.equal(s.meta.lengths, torch.tensor([3]))
         assert s.names == ("F", LENGTH)
 
-    def test_select_feature(self, stream_tensor_3d):
-        s = stream_tensor_3d.select(dim=1, index=1)
+    def test_select_feature(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.select(dim=1, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().select(dim=1, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=1, index=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, LENGTH)
 
-    def test_select_length(self, stream_tensor_3d):
-        s = stream_tensor_3d.select(dim=2, index=1)
+    def test_select_length(self, stream_tensor_3d_fixture):
+        s = stream_tensor_3d_fixture.select(dim=2, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d.tensor().select(dim=2, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=2, index=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([False, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
@@ -261,201 +349,390 @@ class TestSelect:
         assert s.names == (BATCH, "F")
 
 
+class TestTake:
+    def test_take_batch(self, stream_tensor_3d_fixture):
+        # Linear indices that return the entire first batch example but drops other examples for shape (3, 2, 3)
+        indices = torch.tensor([0, 1, 2, 3, 4, 5])
+        s1 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s1, StreamTensor)
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s1.meta.ids == ["first"]
+        assert torch.equal(s1.meta.sos, torch.tensor([True]))
+        assert torch.equal(s1.meta.eos, torch.tensor([False]))
+        assert torch.equal(s1.meta.lengths, torch.tensor([3]))
+        assert s1.names == (join_dim_names("F", LENGTH),)
+
+        # Linear indices that return the entire first batch example but drops the first timestep and other examples
+        indices = torch.tensor([1, 2, 4, 5])
+        s2 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s2, StreamTensor)
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s2.meta.ids == ["first"]
+        assert torch.equal(s2.meta.sos, torch.tensor([False]))
+        assert torch.equal(s2.meta.eos, torch.tensor([False]))
+        assert torch.equal(s2.meta.lengths, torch.tensor([2]))
+        assert s2.names == (join_dim_names("F", LENGTH),)
+
+    def test_take_feature(self, stream_tensor_3d_fixture):
+        # Linear indices that return the entire first feature but drops second feature for shape (3, 2, 3)
+        indices = torch.tensor([0, 1, 2, 6, 7, 8, 12, 13, 14])
+        s1 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s1, StreamTensor)
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s1.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
+        assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
+        assert s1.names == (join_dim_names(BATCH, "F", LENGTH),)
+
+    def test_take_length(self, stream_tensor_3d_fixture):
+        # Linear indices that return the first length step for each example but drops other steps for shape (3, 2, 3)
+        indices = torch.tensor([0, 3, 6, 9, 12, 15])
+        s1 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s1, StreamTensor)
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s1.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))
+        assert torch.equal(s1.meta.lengths, torch.tensor([1, 1, 1]))
+        assert s1.names == (join_dim_names(BATCH, "F"),)
+
+        # Linear indices that return the last length step for each example but drops other steps for shape (3, 2, 3)
+        indices = torch.tensor([2, 5, 8, 11, 14, 17])
+        s1 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s1, StreamTensor)
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s1.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))
+        assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))
+        assert torch.equal(s1.meta.lengths, torch.tensor([1, 1, 0]))
+        assert s1.names == (join_dim_names(BATCH, "F"),)
+
+    def test_take_every_other(self, stream_tensor_3d_fixture):
+        # Linear indices that return every other element of the tensor for shape (3, 2, 3)
+        indices = torch.tensor(range(0, stream_tensor_3d_fixture.numel(), 2))
+        s1 = stream_tensor_3d_fixture.take(indices)
+        assert isinstance(s1, StreamTensor)
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert s1.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
+        assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
+        assert s1.names == (join_dim_names(BATCH, "F", LENGTH),)
+
+
+class TestMaskedSelect:
+    def test_masked_select_batch(self, stream_tensor_3d_fixture):
+        """Masked select on the batch dim keeping only some examples but all other elements."""
+        assert_kwargs = dict(
+            ids=["first", "last"],
+            lengths=[3, 2],
+            sos=[True, False],
+            eos=[False, True],
+            names=(join_dim_names(BATCH, "F", LENGTH),),
+        )
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.masked_select,
+            mask=torch.tensor([True, False, True]).unsqueeze(1).unsqueeze(2),
+            **assert_kwargs,
+        )
+
+    def test_masked_select_feature(self, stream_tensor_3d_fixture):
+        """Masked select on the feature dim keeping only some features but all other elements."""
+        assert_kwargs = dict(
+            ids=["first", "middle", "last"],
+            lengths=[3, 3, 2],
+            sos=[True, False, False],
+            eos=[False, False, True],
+            names=(join_dim_names(BATCH, "F", LENGTH),),
+        )
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.masked_select,
+            mask=torch.tensor([True, False]).unsqueeze(0).unsqueeze(2),
+            **assert_kwargs,
+        )
+
+    def test_masked_select_length(self, stream_tensor_3d_fixture):
+        """Masked select on the length dim keeping only some lengths but all other elements."""
+        assert_kwargs = dict(
+            ids=["first", "middle", "last"],
+            lengths=[1, 1, 0],
+            sos=[False, False, False],
+            eos=[False, False, True],
+            names=(join_dim_names(BATCH, "F", LENGTH),),
+        )
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.masked_select,
+            mask=torch.tensor([False, False, True]).unsqueeze(0).unsqueeze(1),
+            **assert_kwargs,
+        )
+
+
+# class TestFlatten:
+#     def test_flatten_batch(self, stream_tensor_3d_fixture):
+#         raise NotImplementedError
+
+
+class TestUnsqueeze:
+    def test_unsqueeze_single(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, BATCH, "F", LENGTH)
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture,
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_unsqueeze_two(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, "F", LENGTH)
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture.unsqueeze(0),
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_unsqueeze_three(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, None, "F", LENGTH)
+        assert_on_indexing_op(
+            stream_tensor_3d_fixture.unsqueeze(0).unsqueeze(2),
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+
+class TestSqueeze:
+    # def test_squeeze_non_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+    #     stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+    #     assert_on_indexing_op(
+    #         stream_tensor_3d_fixture,
+    #         torch.squeeze,
+    #         dim=0,
+    #         **stream_meta_kwargs_fixture,
+    #     )
+
+    # def test_squeeze_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+    #     s = as_stream_tensor(stream_tensor_3d_fixture.tensor().sum(dim=1, keepdim=True), names=stream_tensor_3d_fixture.names, meta=stream_tensor_3d_fixture.meta)
+    #     stream_meta_kwargs_fixture["names"] = (BATCH, LENGTH)
+    #     assert_on_indexing_op(
+    #         s,
+    #         torch.squeeze,
+    #         dim=1,
+    #         **stream_meta_kwargs_fixture,
+    #     )
+
+    def test_squeeze_all_singleton_dims(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
+        names = (None, None) + stream_tensor_3d_fixture.names
+        s = as_stream_tensor(
+            stream_tensor_3d_fixture.unsqueeze(0).unsqueeze(0), names=names, meta=stream_tensor_3d_fixture.meta
+        )
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_on_indexing_op(
+            s,
+            torch.squeeze,
+            **stream_meta_kwargs_fixture,
+        )
+
+
 ## Indexing (__getitem__)
 
 
 class TestGetitem:
-    def test_feature_indexing_integer(self, stream_tensor_3d):
+    def test_feature_indexing_integer(self, stream_tensor_3d_fixture):
         """Indexing with an integer on the feature dim should remove the feature dim but not change the meta."""
-        s1 = stream_tensor_3d[:, 0, :]
+        s1 = stream_tensor_3d_fixture[:, 0, :]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, 0, :])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, :])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
         assert s1.names == (BATCH, LENGTH)
 
-    def test_batch_indexing_integer(self, stream_tensor_3d):
+    def test_batch_indexing_integer(self, stream_tensor_3d_fixture):
         """Indexing with an integer on the batch dim should remove the batch dim and change the meta to have only that
         one example's metadata."""
-        s1 = stream_tensor_3d[0]
+        s1 = stream_tensor_3d_fixture[0]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[0])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[0])
         assert s1.meta.ids == ["first"]  # changed to only the first example
         assert torch.equal(s1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == ("F", LENGTH)
 
-    def test_batch_indexing_slice(self, stream_tensor_3d):
+    def test_batch_indexing_slice(self, stream_tensor_3d_fixture):
         """Indexing with a slice on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d[1:]
+        s1 = stream_tensor_3d_fixture[1:]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[1:])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[1:])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_tuple(self, stream_tensor_3d):
-        s1 = stream_tensor_3d[(0,)]
+    def test_batch_indexing_tuple(self, stream_tensor_3d_fixture):
+        s1 = stream_tensor_3d_fixture[(0,)]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[(0,)])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[(0,)])
         assert s1.meta.ids == ["first"]
         assert torch.equal(s1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == ("F", LENGTH)
 
-        s2 = stream_tensor_3d[(0, 1)]
+        s2 = stream_tensor_3d_fixture[(0, 1)]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[(0, 1)])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1)])
         assert s2.meta.ids == ["first"]
         assert torch.equal(s2.meta.sos, torch.tensor([True]))
         assert torch.equal(s2.meta.eos, torch.tensor([False]))
         assert torch.equal(s2.meta.lengths, torch.tensor([3]))
         assert s2.names == (LENGTH,)
 
-        s3 = stream_tensor_3d[(0, 1, 2)]
+        s3 = stream_tensor_3d_fixture[(0, 1, 2)]
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[(0, 1, 2)])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1, 2)])
         assert s3.meta.ids == ["first"]
         assert torch.equal(s3.meta.sos, torch.tensor([False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False]))
         assert torch.equal(s3.meta.lengths, torch.tensor([1]))
         assert s3.names == tuple()
 
-        s4 = stream_tensor_3d[(0, 1, 0)]
+        s4 = stream_tensor_3d_fixture[(0, 1, 0)]
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d.tensor()[(0, 1, 0)])
+        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1, 0)])
         assert s4.meta.ids == ["first"]
         assert torch.equal(s4.meta.sos, torch.tensor([True]))
         assert torch.equal(s4.meta.eos, torch.tensor([False]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1]))
         assert s4.names == tuple()
 
-    def test_batch_indexing_list(self, stream_tensor_3d):
+    def test_batch_indexing_list(self, stream_tensor_3d_fixture):
         """Indexing with a list or tuple on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d[[1]]
+        s1 = stream_tensor_3d_fixture[[1]]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[[1]])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[[1]])
         assert s1.meta.ids == ["middle"]
         assert torch.equal(s1.meta.sos, torch.tensor([False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d[[0, 2]]
+        s2 = stream_tensor_3d_fixture[[0, 2]]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[[0, 2]])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[[0, 2]])
         assert s2.meta.ids == ["first", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([3, 2]))
         assert s2.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_booltensor(self, stream_tensor_3d):
+    def test_batch_indexing_booltensor(self, stream_tensor_3d_fixture):
         """Indexing with a bool tensor on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d[torch.tensor([False, True, True])]
+        s1 = stream_tensor_3d_fixture[torch.tensor([False, True, True])]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[torch.tensor([False, True, True])])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[torch.tensor([False, True, True])])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_inttensor(self, stream_tensor_3d):
+    def test_batch_indexing_inttensor(self, stream_tensor_3d_fixture):
         """Indexing with an int tensor on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d[torch.tensor([1, 2])]
+        s1 = stream_tensor_3d_fixture[torch.tensor([1, 2])]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[torch.tensor([1, 2])])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[torch.tensor([1, 2])])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_integer(self, stream_tensor_3d):
+    def test_length_indexing_integer(self, stream_tensor_3d_fixture):
         """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
         or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the
         last non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?).
         """
-        s2 = stream_tensor_3d[:, :, 0]  # first length index
+        s2 = stream_tensor_3d_fixture[:, :, 0]  # first length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, 0])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 0])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s2.names == (BATCH, "F")
 
-        s3 = stream_tensor_3d[:, :, 1]  # middle length index
+        s3 = stream_tensor_3d_fixture[:, :, 1]  # middle length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[:, :, 1])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s3.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s3.names == (BATCH, "F")
 
-        s4 = stream_tensor_3d[:, :, -1]  # last length index
+        s4 = stream_tensor_3d_fixture[:, :, -1]  # last length index
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d.tensor()[:, :, -1])
+        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[:, :, -1])
         assert s4.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # change to False
         assert torch.equal(s4.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 0]))  # changed to 1 and 0
         assert s4.names == (BATCH, "F")
 
-    def test_length_indexing_slice(self, stream_tensor_3d):
+    def test_length_indexing_slice(self, stream_tensor_3d_fixture):
         """Indexing with a slice on the length dim should correctly adjust the meta lengths and sos/eos.
         Specifically,
         - if the slice starts after the first index, no examples should be first.
         - if the slice ends before the last index, no examples should be last.
         - the lengths should be minus the number of non-padding tensor elements that are removed.
         """
-        s2 = stream_tensor_3d[:, :, 1:]  # remove first length index
+        s2 = stream_tensor_3d_fixture[:, :, 1:]  # remove first length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, 1:])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1:])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all)
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d[:, :, :-1]  # remove last length index
+        s3 = stream_tensor_3d_fixture[:, :, :-1]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[:, :, :-1])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, :-1])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-        s4 = stream_tensor_3d[:, :, 1:-1]  # remove first and last length index
+        s4 = stream_tensor_3d_fixture[:, :, 1:-1]  # remove first and last length index
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d.tensor()[:, :, 1:-1])
+        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1:-1])
         assert s4.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s4.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 1]))  # minus 2 for all but "last" since it was padding
         assert s4.names == (BATCH, "F", LENGTH)
 
-        s5 = stream_tensor_3d[:, :, :-2]  # remove two last length indices
+        s5 = stream_tensor_3d_fixture[:, :, :-2]  # remove two last length indices
         assert isinstance(s5, StreamTensor)
-        assert torch.equal(s5.tensor(), stream_tensor_3d.tensor()[:, :, :-2])
+        assert torch.equal(s5.tensor(), stream_tensor_3d_fixture.tensor()[:, :, :-2])
         assert s5.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s5.meta.sos, torch.tensor([True, False, False]))  # changed to False
         assert torch.equal(s5.meta.eos, torch.tensor([False, False, False]))
         assert torch.equal(s5.meta.lengths, torch.tensor([1, 1, 1]))  # minus 2 for all but "last" since it was padding
         assert s5.names == (BATCH, "F", LENGTH)
 
-        s6 = stream_tensor_3d[:, :, ::2]  # remove every other length index from start to end
+        s6 = stream_tensor_3d_fixture[:, :, ::2]  # remove every other length index from start to end
         assert isinstance(s6, StreamTensor)
-        assert torch.equal(s6.tensor(), stream_tensor_3d.tensor()[:, :, ::2])
+        assert torch.equal(s6.tensor(), stream_tensor_3d_fixture.tensor()[:, :, ::2])
         assert s6.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s6.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s6.meta.eos, torch.tensor([False, False, True]))
@@ -469,255 +746,256 @@ class TestGetitem:
             [tuple((1, 2)), tuple((0, 2)), tuple((0, 1))],
         ],
     )
-    def test_length_indexing_tuple_list(self, stream_tensor_3d, indices):
+    def test_length_indexing_tuple_list(self, stream_tensor_3d_fixture, indices):
         """"""
-        s1 = stream_tensor_3d[:, :, indices[0]]  # remove first length index
+        s1 = stream_tensor_3d_fixture[:, :, indices[0]]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, :, indices[0]])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[0]])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d[:, :, indices[1]]  # remove middle length index
+        s2 = stream_tensor_3d_fixture[:, :, indices[1]]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, indices[1]])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[1]])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d[:, :, indices[2]]  # remove last length index
+        s3 = stream_tensor_3d_fixture[:, :, indices[2]]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[:, :, indices[2]])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[2]])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_list(self, stream_tensor_3d):
+    def test_length_indexing_list(self, stream_tensor_3d_fixture):
         """"""
-        s1 = stream_tensor_3d[:, :, [1, 2]]  # remove first length index
+        s1 = stream_tensor_3d_fixture[:, :, [1, 2]]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, :, [1, 2]])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [1, 2]])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d[:, :, [0, 2]]  # remove middle length index
+        s2 = stream_tensor_3d_fixture[:, :, [0, 2]]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, [0, 2]])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [0, 2]])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d[:, :, [0, 1]]  # remove last length index
+        s3 = stream_tensor_3d_fixture[:, :, [0, 1]]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[:, :, [0, 1]])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [0, 1]])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_1d_inttensor(self, stream_tensor_3d):
+    def test_length_indexing_1d_inttensor(self, stream_tensor_3d_fixture):
         """"""
-        s1 = stream_tensor_3d[:, :, torch.tensor([1, 2])]  # remove first length index
+        s1 = stream_tensor_3d_fixture[:, :, torch.tensor([1, 2])]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, :, torch.tensor([1, 2])])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([1, 2])])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d[:, :, torch.tensor([0, 2])]  # remove middle length index
+        s2 = stream_tensor_3d_fixture[:, :, torch.tensor([0, 2])]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, torch.tensor([0, 2])])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([0, 2])])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d[:, :, torch.tensor([0, 1])]  # remove last length index
+        s3 = stream_tensor_3d_fixture[:, :, torch.tensor([0, 1])]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[:, :, torch.tensor([0, 1])])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([0, 1])])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_1d_booltensor(self, stream_tensor_3d):
+    def test_length_indexing_1d_booltensor(self, stream_tensor_3d_fixture):
         """Test that we can index a StreamTensor with a bool tensor (mask)."""
-        s1 = stream_tensor_3d[:, :, torch.tensor([False, True, True])]  # remove first length index
+        s1 = stream_tensor_3d_fixture[:, :, torch.tensor([False, True, True])]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, :, torch.tensor([False, True, True])])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([False, True, True])])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d[:, :, torch.tensor([True, True, False])]  # remove last length index
+        s2 = stream_tensor_3d_fixture[:, :, torch.tensor([True, True, False])]  # remove last length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, :, torch.tensor([True, True, False])])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([True, True, False])])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but last since this was padding.
         assert s2.names == (BATCH, "F", LENGTH)
 
-    def test_indexing_ellipsis(self, stream_tensor_3d):
+    def test_indexing_ellipsis(self, stream_tensor_3d_fixture):
         """Test that we can index a StreamTensor with an ellipsis."""
-        s1_1 = stream_tensor_3d[0, ...]  # keep only first batch example
+        s1_1 = stream_tensor_3d_fixture[0, ...]  # keep only first batch example
         assert isinstance(s1_1, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d.tensor()[0, ...])
+        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, ...])
         assert s1_1.meta.ids == ["first"]
         assert torch.equal(s1_1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1_1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1_1.meta.lengths, torch.tensor([3]))
         assert s1_1.names == ("F", LENGTH)
 
-        s1_2 = stream_tensor_3d[0, ..., :]  # keep only first batch example
+        s1_2 = stream_tensor_3d_fixture[0, ..., :]  # keep only first batch example
         assert isinstance(s1_2, StreamTensor)
-        assert torch.equal(s1_2.tensor(), stream_tensor_3d.tensor()[0, ..., :])
+        assert torch.equal(s1_2.tensor(), stream_tensor_3d_fixture.tensor()[0, ..., :])
         assert s1_2.meta.ids == ["first"]
         assert torch.equal(s1_2.meta.sos, torch.tensor([True]))
         assert torch.equal(s1_2.meta.eos, torch.tensor([False]))
         assert torch.equal(s1_2.meta.lengths, torch.tensor([3]))
         assert s1_1.names == ("F", LENGTH)
 
-        s1_3 = stream_tensor_3d[0, :, ...]  # keep only first batch example
+        s1_3 = stream_tensor_3d_fixture[0, :, ...]  # keep only first batch example
         assert isinstance(s1_3, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d.tensor()[0, :, ...])
+        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, :, ...])
         assert s1_3.meta.ids == ["first"]
         assert torch.equal(s1_3.meta.sos, torch.tensor([True]))
         assert torch.equal(s1_3.meta.eos, torch.tensor([False]))
         assert torch.equal(s1_3.meta.lengths, torch.tensor([3]))
         assert s1_1.names == ("F", LENGTH)
 
-        s1_4 = stream_tensor_3d[0, ..., ...]  # keep only first batch example
+        s1_4 = stream_tensor_3d_fixture[0, ..., ...]  # keep only first batch example
         assert isinstance(s1_4, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d.tensor()[0, ..., ...])
+        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, ..., ...])
         assert s1_4.meta.ids == ["first"]
         assert torch.equal(s1_4.meta.sos, torch.tensor([True]))
         assert torch.equal(s1_4.meta.eos, torch.tensor([False]))
         assert torch.equal(s1_4.meta.lengths, torch.tensor([3]))
         assert s1_1.names == ("F", LENGTH)
 
-        s2 = stream_tensor_3d[..., 0]  # keep only first length index
+        s2 = stream_tensor_3d_fixture[..., 0]  # keep only first length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[..., 0])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[..., 0])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # set to 1
         assert s2.names == (BATCH, "F")
 
-        s3 = stream_tensor_3d[..., 0, ...]  # keep only first feature dim
+        s3 = stream_tensor_3d_fixture[..., 0, ...]  # keep only first feature dim
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor()[..., 0, ...])
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[..., 0, ...])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s3.meta.lengths, torch.tensor([3, 3, 2]))
         assert s3.names == (BATCH, LENGTH)
 
-    def test_batch_and_feature_indexing_2d_booltensor(self, stream_tensor_3d):
+    def test_batch_and_feature_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the batch and feature dimensions."""
         indices = torch.tensor([[True, True], [False, True], [True, False]])  # Keep only some features
-        s1 = stream_tensor_3d[indices]
+        s1 = stream_tensor_3d_fixture[indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[indices])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
         assert s1.shape == (4, 3)
-        assert s1.names == (dreamstream.overrides.join_dim_names(BATCH, "F"), LENGTH)
+        assert s1.names == (join_dim_names(BATCH, "F"), LENGTH)
 
-    def test_length_and_feature_indexing_2d_booltensor(self, stream_tensor_3d):
+    def test_length_and_feature_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the length and feature dimensions."""
         # keep all lenghts of one feature and some of other
         indices = torch.tensor([[True, True, True], [True, False, False]])
-        s1 = stream_tensor_3d[:, indices]
+        s1 = stream_tensor_3d_fixture[:, indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, indices])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
-        assert s1.names == (BATCH, dreamstream.overrides.join_dim_names("F", LENGTH))
+        assert s1.names == (BATCH, join_dim_names("F", LENGTH))
 
         indices = torch.tensor([[True, False, False], [True, False, False]])  # remove last two time steps of features
-        s2 = stream_tensor_3d[:, indices]
+        s2 = stream_tensor_3d_fixture[:, indices]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor()[:, indices])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))
         assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
-        assert s2.names == (BATCH, dreamstream.overrides.join_dim_names("F", LENGTH))
+        assert s2.names == (BATCH, join_dim_names("F", LENGTH))
 
-    def test_batch_and_length_indexing_2d_booltensor(self, stream_tensor_3d):
+    def test_batch_and_length_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the length and feature dimensions."""
         # sos=[True, False, False], eos=[False, False, True],
         indices = torch.tensor([[True, True, True], [True, False, False], [True, True, True]])  # (B, T) = (3, 3)
-        s1 = stream_tensor_3d.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
+        s1 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
         s1 = s1[indices]  # (B, T, F) -> (B_T, F)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor().permute(0, 2, 1)[indices])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 1, 2]))  # changed to 1
-        assert s1.names == (dreamstream.overrides.join_dim_names(BATCH, LENGTH), "F")
+        assert s1.names == (join_dim_names(BATCH, LENGTH), "F")
 
         # Remove middle example altogether
         indices = torch.tensor([[True, True, True], [False, False, False], [True, True, True]])  # (B, T) = (3, 3)
-        s2 = stream_tensor_3d.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
+        s2 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
         s2 = s2[indices]  # (B, T, F) -> (B_T, F)
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d.tensor().permute(0, 2, 1)[indices])
+        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
         assert s2.meta.ids == ["first", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([3, 2]))
-        assert s2.names == (dreamstream.overrides.join_dim_names(BATCH, LENGTH), "F")
+        assert s2.names == (join_dim_names(BATCH, LENGTH), "F")
 
-        indices = torch.tensor([[False, True, True], [True, False, False], [True, False, False]])  # (B, T) = (3, 3)
-        s3 = stream_tensor_3d.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
+        # Remove middle example and first time step of first example and last two timesteps of last example
+        indices = torch.tensor([[False, True, True], [False, False, False], [True, False, False]])  # (B, T) = (3, 3)
+        s3 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
         s3 = s3[indices]  # (B, T, F) -> (B_T, F)
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d.tensor().permute(0, 2, 1)[indices])
-        assert s3.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s3.meta.sos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s3.meta.lengths, torch.tensor([2, 1, 1]))  # changed to 1
-        assert s3.names == (dreamstream.overrides.join_dim_names(BATCH, LENGTH), "F")
+        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
+        assert s3.meta.ids == ["first", "last"]
+        assert torch.equal(s3.meta.sos, torch.tensor([False, False]))  # changed to False
+        assert torch.equal(s3.meta.eos, torch.tensor([False, False]))  # changed to False
+        assert torch.equal(s3.meta.lengths, torch.tensor([2, 1]))  # minus 1
+        assert s3.names == (join_dim_names(BATCH, LENGTH), "F")
 
         # Transposed version of s3
-        indices = indices.transpose(0, 1)  # (B, T) -> (T, B)
-        s4 = stream_tensor_3d.permute(2, 0, 1)  # (B, F, T) -> (T, B, F)
+        # Remove middle timestep for all examples, include first timestep for middle and last, last timestep for first
+        s4 = stream_tensor_3d_fixture.permute(2, 0, 1)  # (B, F, T) -> (T, B, F)
         s4 = s4[indices]  # (B, T, F) -> (B_T, F)
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d.tensor().permute(2, 0, 1)[indices])
+        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor().permute(2, 0, 1)[indices])
         assert s4.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s4.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s4.meta.lengths, torch.tensor([2, 1, 1]))  # changed to 1
-        assert s4.names == (dreamstream.overrides.join_dim_names(LENGTH, BATCH), "F")
+        assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 1]))  # minus 1
+        assert s4.names == (join_dim_names(LENGTH, BATCH), "F")
 
-    def test_batch_and_length_indexing_3d_booltensor(self, stream_tensor_3d):
+    def test_batch_and_length_indexing_3d_booltensor(self, stream_tensor_3d_fixture):
         """Test indexing a StreamTensor with a 3D BoolTensor along the batch, feature and length dimensions."""
         indices = torch.tensor(
             [
@@ -735,20 +1013,20 @@ class TestGetitem:
                 ],
             ]
         )  # (B, T) = (3, 3)
-        s1 = stream_tensor_3d[indices]  # (B, T, F) -> (B_T, F)
+        s1 = stream_tensor_3d_fixture[indices]  # (B, T, F) -> (B_T, F)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[indices])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 1, 1]))  # changed to 1
-        assert s1.names == (dreamstream.overrides.join_dim_names(BATCH, "F", LENGTH),)
+        assert s1.names == (join_dim_names(BATCH, "F", LENGTH),)
 
-    def test_feature_indexing_2d_inttensor(self, stream_tensor_3d):
+    def test_feature_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
         indices = torch.tensor([[0, 1], [1, 1]])
-        s1 = stream_tensor_3d[:, indices]
+        s1 = stream_tensor_3d_fixture[:, indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, indices])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
@@ -756,51 +1034,51 @@ class TestGetitem:
         assert s1.names == (BATCH, None, "F", LENGTH)
         assert s1.shape == (3, 2, 2, 3)
 
-    def test_batch_indexing_2d_inttensor(self, stream_tensor_3d):
+    def test_batch_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
         indices = torch.tensor([[0, 1, 2], [0, 1, 2]])
         with pytest.raises(IndexError):
-            stream_tensor_3d[indices]
+            stream_tensor_3d_fixture[indices]
 
-    def test_length_indexing_2d_inttensor(self, stream_tensor_3d):
+    def test_length_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
         indices = torch.tensor([[0, 1], [1, 1]])
         with pytest.raises(IndexError):
-            stream_tensor_3d[..., indices]
+            stream_tensor_3d_fixture[..., indices]
 
-    def test_length_indexing_integer_multidimensional(self, stream_tensor_3d):
+    def test_length_indexing_integer_multidimensional(self, stream_tensor_3d_fixture):
         """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
         or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the last
         non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?). This case also tests that we
         can simultaneously index the feature dimension without affecting the length indexing.
         """
-        s1 = stream_tensor_3d[:, 0, 0]  # first length index and first feature index
+        s1 = stream_tensor_3d_fixture[:, 0, 0]  # first length index and first feature index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, 0, 0])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, 0])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s1.names == (BATCH,)
 
-    def test_length_indexing_slice_multidimensional(self, stream_tensor_3d):
+    def test_length_indexing_slice_multidimensional(self, stream_tensor_3d_fixture):
         """Indexing with a slice on the length dim should correctly adjust the meta lengths and sos/eos.
         This case also tests that we can simultaneously index the feature dimension without affecting the length
         indexing.
         """
-        s1 = stream_tensor_3d[:, 0, 1:]  # remove first length index and first feature index
+        s1 = stream_tensor_3d_fixture[:, 0, 1:]  # remove first length index and first feature index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:, 0, 1:])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, 1:])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, LENGTH)
 
-    def test_batch_and_length_indexing_slice(self, stream_tensor_3d):
+    def test_batch_and_length_indexing_slice(self, stream_tensor_3d_fixture):
         """Indexing with a slice on the batch dim and a slice on the length dim should have the combined effect of
         both."""
-        s1 = stream_tensor_3d[:-1, :, 1:]  # remove last batch index and first length index
+        s1 = stream_tensor_3d_fixture[:-1, :, 1:]  # remove last batch index and first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d.tensor()[:-1, :, 1:])
+        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:-1, :, 1:])
         assert s1.meta.ids == ["first", "middle"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False]))

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -182,8 +182,8 @@ class TestIndexing:
 
 
     def test_batch_indexing_integer(self, stream_tensor_3d):
-        """Indexing with an integer on the batch dim should remove the batch dim and change the meta to have only that one
-        example's metadata."""
+        """Indexing with an integer on the batch dim should remove the batch dim and change the meta to have only that 
+        one example's metadata."""
         s1 = stream_tensor_3d[0]
 
         assert isinstance(s1, StreamTensor)
@@ -246,8 +246,8 @@ class TestIndexing:
 
 
     def test_length_indexing_integer(self, stream_tensor_3d):
-        """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1 or
-        0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the
+        """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
+        or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the
         last non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?).
         """
         s2 = stream_tensor_3d[:, :, 0]  # first length index
@@ -400,7 +400,7 @@ class TestIndexing:
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since this was padding.
+        assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but last since this was padding.
         assert s2.names == (BATCH, "F", LENGTH)
 
 
@@ -488,7 +488,7 @@ class TestIndexing:
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
         assert s1.names == (BATCH, dreamstream.overrides.join_dim_names("F", LENGTH))
 
-        indices = torch.tensor([[True, False, False], [True, False, False]])  # remove two last length steps of each feature
+        indices = torch.tensor([[True, False, False], [True, False, False]])  # remove last two steps of each feature
         s2 = stream_tensor_3d[:, indices]
 
         assert isinstance(s2, StreamTensor)
@@ -550,7 +550,7 @@ class TestIndexing:
 
 
     def test_batch_and_length_indexing_3d_booltensor(self, stream_tensor_3d):
-        """Test that we can index a StreamTensor with a 3d bool tensor along the batch, feature and length dimensions."""
+        """Test indexing a StreamTensor with a 3D BoolTensor along the batch, feature and length dimensions."""
         indices = torch.tensor(
             [
                 [
@@ -604,10 +604,10 @@ class TestIndexing:
 
 
     def test_length_indexing_integer_multidimensional(self, stream_tensor_3d):
-        """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1 or
-        0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the
-        last non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?).
-        This case also tests that we can simultaneously index the feature dimension without affecting the length indexing.
+        """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
+        or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the last
+        non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?). This case also tests that we
+        can simultaneously index the feature dimension without affecting the length indexing.
         """
         s1 = stream_tensor_3d[:, 0, 0]  # first length index and first feature index
 
@@ -621,7 +621,8 @@ class TestIndexing:
 
     def test_length_indexing_slice_multidimensional(self, stream_tensor_3d):
         """Indexing with a slice on the length dim should correctly adjust the meta lengths and sos/eos.
-        This case also tests that we can simultaneously index the feature dimension without affecting the length indexing.
+        This case also tests that we can simultaneously index the feature dimension without affecting the length 
+        indexing.
         """
         s1 = stream_tensor_3d[:, 0, 1:]  # remove first length index and first feature index
 
@@ -634,7 +635,8 @@ class TestIndexing:
 
 
     def test_batch_and_length_indexing_slice(self, stream_tensor_3d):
-        """Indexing with a slice on the batch dim and a slice on the length dim should have the combined effect of both."""
+        """Indexing with a slice on the batch dim and a slice on the length dim should have the combined effect of 
+        both."""
         s1 = stream_tensor_3d[:-1, :, 1:]  # remove last batch index and first length index
 
         assert isinstance(s1, StreamTensor)

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -15,7 +15,11 @@ from dreamstream.func_coverage import (
 from dreamstream.overrides import join_dim_names
 
 
-def test_data():
+def test_data_2d():
+    return [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+
+def test_data_3d():
     return [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]], [[13, 14, 15], [16, 17, 18]]]
 
 
@@ -28,30 +32,66 @@ def test_meta_kwargs():
     )
 
 
+def stream_tensor_bl():
+    """StreamTensor with shape (B, L) = (3, 3)"""
+    test_meta = stream_metadata(**test_meta_kwargs())
+    return stream_tensor(torch.as_tensor(test_data_2d()), test_meta, names=(BATCH, LENGTH))  # (3, 3)
+
+
+def stream_tensor_bfl():
+    """StreamTensor with shape (B, F, L) = (3, 2, 3)"""
+    test_meta = stream_metadata(**test_meta_kwargs())
+    return stream_tensor(test_data_3d(), test_meta, names=(BATCH, "F", LENGTH))  # (3, 2, 3)
+
+
+def stream_tensor_lbf():
+    """StreamTensor with shape (L, B, F) = (3, 3, 2)"""
+    test_meta = stream_metadata(**test_meta_kwargs())
+    data = torch.as_tensor(test_data_3d()).permute(2, 0, 1)  # (L, B, F) = (3, 3, 2)
+    return stream_tensor(data, test_meta, names=(LENGTH, BATCH, "F"))
+
+
+def stream_tensor_blf():
+    """StreamTensor with shape (B, L, F) = (3, 3, 2)"""
+    test_meta = stream_metadata(**test_meta_kwargs())
+    data = torch.as_tensor(test_data_3d()).permute(0, 2, 1)  # (B, L, F) = (3, 3, 2)
+    return stream_tensor(data, test_meta, names=(LENGTH, BATCH, "F"))
+
+
+def stream_tensor_bfld():
+    """ "StreamTensor with shape (B, F, L, D) = (2, 3, 2, 3)"""
+    test_meta = stream_metadata(**test_meta_kwargs())
+    test_tensor_data = torch.stack([torch.as_tensor(test_data_3d()), torch.as_tensor(test_data_3d())], dim=2)
+    return stream_tensor(test_tensor_data, test_meta, names=(BATCH, "F", "D", LENGTH))  # (2, 3, 2, 3)
+
+
 @pytest.fixture()
 def stream_meta_kwargs_fixture():
     return test_meta_kwargs()
 
 
-def stream_tensor_3d():
-    test_meta = stream_metadata(**test_meta_kwargs())
-    return stream_tensor(test_data(), test_meta, names=(BATCH, "F", LENGTH))  # (3, 2, 3)
+@pytest.fixture()
+def stream_tensor_bfl_fixture():
+    """StreamTensor with shape (B, F, L) = (3, 2, 3)"""
+    return stream_tensor_bfl()
 
 
 @pytest.fixture()
-def stream_tensor_3d_fixture():
-    return stream_tensor_3d()
-
-
-def stream_tensor_4d():
-    test_meta = stream_metadata(**test_meta_kwargs())
-    test_tensor_data = torch.stack([torch.as_tensor(test_data()), torch.as_tensor(test_data())], dim=2)
-    return stream_tensor(test_tensor_data, test_meta, names=(BATCH, "F", "D", LENGTH))  # (2, 3, 2, 3)
+def stream_tensor_lbf_fixture():
+    """StreamTensor with shape (L, B, F) = (3, 3, 2)"""
+    return stream_tensor_lbf()
 
 
 @pytest.fixture()
-def stream_tensor_4d_fixture():
-    return stream_tensor_4d()
+def stream_tensor_blf_fixture():
+    """StreamTensor with shape (L, B, F) = (3, 3, 2)"""
+    return stream_tensor_blf()
+
+
+@pytest.fixture()
+def stream_tensor_bfld_fixture():
+    """StreamTensor with shape (B, F, L, D) = (2, 3, 2, 3)"""
+    return stream_tensor_bfld()
 
 
 ## Instantiation
@@ -89,34 +129,46 @@ class Inputs:
 
 
 def to_torch_tensor_recursive(x):
+    """Helper function similar to `decouple_recursive`."""
     if isinstance(x, StreamTensor):
         return x.tensor()
-    elif isinstance(x, Sequence):
+    elif isinstance(x, (list, tuple)):
         return type(x)(to_torch_tensor_recursive(xi) for xi in x)
-    elif isinstance(x, Mapping):
+    elif isinstance(x, dict):
         return type(x)((k, to_torch_tensor_recursive(v)) for k, v in x.items())
     return x
 
 
 TEST_INPUTS_VALID_FUNCTIONS = {
-    torch.Tensor.__repr__: Inputs(stream_tensor_3d()),
+    torch.Tensor.__repr__: Inputs(stream_tensor_bfl()),
 }
 
 TEST_INPUTS_DECOUPLE_FUNCTIONS = {
-    torch.argmax: Inputs(stream_tensor_3d(), dim=-1),
-    torch.argmin: Inputs(stream_tensor_3d(), dim=-1),
-    torch.argsort: Inputs(stream_tensor_3d(), dim=-1),
+    torch.argmax: Inputs(stream_tensor_bfl(), dim=-1),
+    torch.argmin: Inputs(stream_tensor_bfl(), dim=-1),
+    torch.argsort: Inputs(stream_tensor_bfl(), dim=-1),
 }
 
 TEST_INPUTS_RECOUPLE_FUNCTIONS = {
-    torch.adjoint: Inputs(stream_tensor_3d()),
-    torch.sigmoid: Inputs(stream_tensor_3d()),
-    torch.Tensor.sigmoid: Inputs(stream_tensor_3d()),
-    torch.transpose: Inputs(stream_tensor_3d(), dim0=0, dim1=1),
-    torch.where: Inputs(stream_tensor_3d() > 5, input=stream_tensor_3d() - 1, other=stream_tensor_3d()),
-    torch.where: Inputs(stream_tensor_3d() > 5, input=stream_tensor_3d() - 1, other=2),
-    torch.Tensor.where: Inputs(stream_tensor_3d(), condition=stream_tensor_3d() > 5, other=stream_tensor_3d()),
+    torch.adjoint: Inputs(stream_tensor_bfl()),
+    torch.sigmoid: Inputs(stream_tensor_bfl()),
+    torch.Tensor.sigmoid: Inputs(stream_tensor_bfl()),
+    torch.transpose: Inputs(stream_tensor_bfl(), dim0=0, dim1=1),
+    torch.where: Inputs(stream_tensor_bfl() > 5, input=stream_tensor_bfl() - 1, other=stream_tensor_bfl()),
+    torch.where: Inputs(stream_tensor_bfl() > 5, input=stream_tensor_bfl() - 1, other=2),
+    torch.Tensor.where: Inputs(stream_tensor_bfl(), condition=stream_tensor_bfl() > 5, other=stream_tensor_bfl()),
+    torch.scatter: Inputs(
+        stream_tensor_bl(),
+        dim=0,
+        index=torch.tensor([[0, 1, 2], [0, 1, 2]]),
+        src=stream_tensor_bl() * 2,
+    ),
 }
+
+
+TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.scatter_] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.scatter]
+TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.scatter] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.scatter]
+
 
 TEST_SKIP_EQUALITY_CHECK = {torch.Tensor.__repr__}
 
@@ -159,11 +211,11 @@ def test_valid_coupled_recoupled_functions():
         raise AssertionError("\n\n" + err)
 
 
-# def test_unsupported_functions(stream_tensor_3d_fixture):
+# def test_unsupported_functions(stream_tensor_bfl_fixture):
 #     failed = []
 #     for f in UNSUPPORTED_FUNCTIONS:
 #         try:
-#             f(stream_tensor_3d_fixture)
+#             f(stream_tensor_bfl_fixture)
 #         except Exception as e:
 #             failed.append((f, e))
 
@@ -190,9 +242,13 @@ def test_function_coverage():
 
 
 def assert_stream_tensor_and_meta_correct(stream_tensor, func, *args, ids, lengths, sos, eos, names, **kwargs):
-    # TODO (JDH): Use this method for all indexing tests to reduce verbosity.
+    """Assert that a function returns a StreamTensor with the correct metadata when applied to a StreamTensor.
+
+    The output is expected to be equal in value to the output when the function is applied to an identical torch.Tensor.
+    """
     s = func(stream_tensor, *args, **kwargs)
-    t = func(stream_tensor.tensor(), *args, **kwargs)
+    torch_tensor, args, kwargs = to_torch_tensor_recursive((stream_tensor, args, kwargs))
+    t = func(torch_tensor, *args, **kwargs)
     assert isinstance(s, StreamTensor)
     assert torch.equal(s.tensor(), t)
     assert s.meta.ids == ids
@@ -202,7 +258,11 @@ def assert_stream_tensor_and_meta_correct(stream_tensor, func, *args, ids, lengt
     assert s.names == names
 
 
-def assert_tensor_and_nameless(stream_tensor, func, *args, **kwargs):
+def assert_fallback_to_torch_tensor(stream_tensor, func, *args, **kwargs):
+    """Assert that a function falls back to return a torch.Tensor when applied to a StreamTensor.
+
+    The torch.Tensor is expected to have no names and be equal in value to the StreamTensor's tensor.
+    """
     s = func(stream_tensor, *args, **kwargs)
     t = func(stream_tensor.tensor(), *args, **kwargs)
     assert isinstance(s, torch.Tensor) and not isinstance(s, StreamTensor)
@@ -211,7 +271,7 @@ def assert_tensor_and_nameless(stream_tensor, func, *args, **kwargs):
 
 
 class TestNarrow:
-    def test_narrow_batch(self, stream_tensor_3d_fixture):
+    def test_narrow_batch(self, stream_tensor_bfl_fixture):
         """Test `torch.narrow` on a StreamTensor when applied to batch, length, and feature dimensions."""
         assert_kwargs = dict(
             ids=["middle", "last"],
@@ -221,7 +281,7 @@ class TestNarrow:
             names=(BATCH, "F", LENGTH),
         )
         assert_stream_tensor_and_meta_correct(
-            stream_tensor_3d_fixture,
+            stream_tensor_bfl_fixture,
             torch.narrow,
             dim=0,
             start=1,
@@ -229,20 +289,20 @@ class TestNarrow:
             **assert_kwargs,
         )
 
-    def test_narrow_feature(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.narrow(dim=1, start=1, length=1)
+    def test_narrow_feature(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.narrow(dim=1, start=1, length=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().narrow(dim=1, start=1, length=1))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().narrow(dim=1, start=1, length=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_narrow_length(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.narrow(dim=2, start=1, length=2)
+    def test_narrow_length(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.narrow(dim=2, start=1, length=2)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().narrow(dim=2, start=1, length=2))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().narrow(dim=2, start=1, length=2))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([False, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
@@ -281,47 +341,47 @@ class TestGather:
         ]
     )
 
-    def test_gather_batch(self, stream_tensor_3d_fixture):
+    def test_gather_batch(self, stream_tensor_bfl_fixture):
         """Test `torch.gather` on a StreamTensor when applied to batch, length, and feature dimensions."""
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture.gather(dim=0, index=self.full_index)
+            stream_tensor_bfl_fixture.gather(dim=0, index=self.full_index)
 
-    def test_gather_feature(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.gather(dim=1, index=self.full_index)
+    def test_gather_feature(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.gather(dim=1, index=self.full_index)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().gather(dim=1, index=self.full_index))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().gather(dim=1, index=self.full_index))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_gather_feature_truncated(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.gather(dim=1, index=self.truncated_index)
+    def test_gather_feature_truncated(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.gather(dim=1, index=self.truncated_index)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().gather(dim=1, index=self.truncated_index))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().gather(dim=1, index=self.truncated_index))
         assert s.meta.ids == ["first", "middle"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False]))
         assert torch.equal(s.meta.lengths, torch.tensor([2, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_gather_length(self, stream_tensor_3d_fixture):
+    def test_gather_length(self, stream_tensor_bfl_fixture):
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture.gather(dim=2, index=self.full_index)
+            stream_tensor_bfl_fixture.gather(dim=2, index=self.full_index)
 
 
 class TestTakeAlongDim:
-    def test_take_along_batch(self, stream_tensor_3d_fixture):
+    def test_take_along_batch(self, stream_tensor_bfl_fixture):
         """Test `torch.take_along_dim` on a StreamTensor when applied to batch, length, and feature dimensions."""
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture.take_along_dim(dim=0, indices=TestGather.full_index)
+            stream_tensor_bfl_fixture.take_along_dim(dim=0, indices=TestGather.full_index)
 
-    def test_take_along_feature(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.full_index)
+    def test_take_along_feature(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.take_along_dim(dim=1, indices=TestGather.full_index)
         assert isinstance(s, StreamTensor)
         assert torch.equal(
-            s.tensor(), stream_tensor_3d_fixture.tensor().take_along_dim(dim=1, indices=TestGather.full_index)
+            s.tensor(), stream_tensor_bfl_fixture.tensor().take_along_dim(dim=1, indices=TestGather.full_index)
         )
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
@@ -329,41 +389,41 @@ class TestTakeAlongDim:
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, "F", LENGTH)
 
-    def test_take_along_feature_truncated(self, stream_tensor_3d_fixture):
+    def test_take_along_feature_truncated(self, stream_tensor_bfl_fixture):
         with pytest.raises(RuntimeError):
-            stream_tensor_3d_fixture.take_along_dim(dim=1, indices=TestGather.truncated_index)
+            stream_tensor_bfl_fixture.take_along_dim(dim=1, indices=TestGather.truncated_index)
 
-    def test_take_along_length(self, stream_tensor_3d_fixture):
+    def test_take_along_length(self, stream_tensor_bfl_fixture):
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture.take_along_dim(dim=2, indices=TestGather.full_index)
+            stream_tensor_bfl_fixture.take_along_dim(dim=2, indices=TestGather.full_index)
 
 
 class TestSelect:
-    def test_select_batch(self, stream_tensor_3d_fixture):
+    def test_select_batch(self, stream_tensor_bfl_fixture):
         """Test `torch.select` on a StreamTensor when applied to batch, length, and feature dimensions."""
-        s = stream_tensor_3d_fixture.select(dim=0, index=1)
+        s = stream_tensor_bfl_fixture.select(dim=0, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=0, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().select(dim=0, index=1))
         assert s.meta.ids == ["middle"]
         assert torch.equal(s.meta.sos, torch.tensor([False]))
         assert torch.equal(s.meta.eos, torch.tensor([False]))
         assert torch.equal(s.meta.lengths, torch.tensor([3]))
         assert s.names == ("F", LENGTH)
 
-    def test_select_feature(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.select(dim=1, index=1)
+    def test_select_feature(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.select(dim=1, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=1, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().select(dim=1, index=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s.meta.lengths, torch.tensor([3, 3, 2]))
         assert s.names == (BATCH, LENGTH)
 
-    def test_select_length(self, stream_tensor_3d_fixture):
-        s = stream_tensor_3d_fixture.select(dim=2, index=1)
+    def test_select_length(self, stream_tensor_bfl_fixture):
+        s = stream_tensor_bfl_fixture.select(dim=2, index=1)
         assert isinstance(s, StreamTensor)
-        assert torch.equal(s.tensor(), stream_tensor_3d_fixture.tensor().select(dim=2, index=1))
+        assert torch.equal(s.tensor(), stream_tensor_bfl_fixture.tensor().select(dim=2, index=1))
         assert s.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s.meta.sos, torch.tensor([False, False, False]))
         assert torch.equal(s.meta.eos, torch.tensor([False, False, True]))
@@ -372,12 +432,12 @@ class TestSelect:
 
 
 class TestTake:
-    def test_take_batch(self, stream_tensor_3d_fixture):
+    def test_take_batch(self, stream_tensor_bfl_fixture):
         # Linear indices that return the entire first batch example but drops other examples for shape (3, 2, 3)
         indices = torch.tensor([0, 1, 2, 3, 4, 5])
-        s1 = stream_tensor_3d_fixture.take(indices)
+        s1 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s1.meta.ids == ["first"]
         assert torch.equal(s1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
@@ -386,33 +446,33 @@ class TestTake:
 
         # Linear indices that return the entire first batch example but drops the first timestep and other examples
         indices = torch.tensor([1, 2, 4, 5])
-        s2 = stream_tensor_3d_fixture.take(indices)
+        s2 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s2.meta.ids == ["first"]
         assert torch.equal(s2.meta.sos, torch.tensor([False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2]))
         assert s2.names == (join_dim_names("F", LENGTH),)
 
-    def test_take_feature(self, stream_tensor_3d_fixture):
+    def test_take_feature(self, stream_tensor_bfl_fixture):
         # Linear indices that return the entire first feature but drops second feature for shape (3, 2, 3)
         indices = torch.tensor([0, 1, 2, 6, 7, 8, 12, 13, 14])
-        s1 = stream_tensor_3d_fixture.take(indices)
+        s1 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
         assert s1.names == (join_dim_names(BATCH, "F", LENGTH),)
 
-    def test_take_length(self, stream_tensor_3d_fixture):
+    def test_take_length(self, stream_tensor_bfl_fixture):
         # Linear indices that return the first length step for each example but drops other steps for shape (3, 2, 3)
         indices = torch.tensor([0, 3, 6, 9, 12, 15])
-        s1 = stream_tensor_3d_fixture.take(indices)
+        s1 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))
@@ -421,21 +481,21 @@ class TestTake:
 
         # Linear indices that return the last length step for each example but drops other steps for shape (3, 2, 3)
         indices = torch.tensor([2, 5, 8, 11, 14, 17])
-        s1 = stream_tensor_3d_fixture.take(indices)
+        s1 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([1, 1, 0]))
         assert s1.names == (join_dim_names(BATCH, "F"),)
 
-    def test_take_every_other(self, stream_tensor_3d_fixture):
+    def test_take_every_other(self, stream_tensor_bfl_fixture):
         # Linear indices that return every other element of the tensor for shape (3, 2, 3)
-        indices = torch.tensor(range(0, stream_tensor_3d_fixture.numel(), 2))
-        s1 = stream_tensor_3d_fixture.take(indices)
+        indices = torch.tensor(range(0, stream_tensor_bfl_fixture.numel(), 2))
+        s1 = stream_tensor_bfl_fixture.take(indices)
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().take(indices))
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor().take(indices))
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
@@ -444,110 +504,28 @@ class TestTake:
 
 
 class TestMaskedSelect:
-    def test_masked_select_batch(self, stream_tensor_3d_fixture):
+    def test_masked_select_batch(self, stream_tensor_bfl_fixture):
         """Masked select on the batch dim keeping only some examples but all other elements."""
-        assert_tensor_and_nameless(
-            stream_tensor_3d_fixture,
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
             torch.masked_select,
             mask=torch.tensor([True, False, True]).unsqueeze(1).unsqueeze(2),
         )
 
-    def test_masked_select_feature(self, stream_tensor_3d_fixture):
+    def test_masked_select_feature(self, stream_tensor_bfl_fixture):
         """Masked select on the feature dim keeping only some features but all other elements."""
-        assert_tensor_and_nameless(
-            stream_tensor_3d_fixture,
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
             torch.masked_select,
             mask=torch.tensor([True, False]).unsqueeze(0).unsqueeze(2),
         )
 
-    def test_masked_select_length(self, stream_tensor_3d_fixture):
+    def test_masked_select_length(self, stream_tensor_bfl_fixture):
         """Masked select on the length dim keeping only some lengths but all other elements."""
-        assert_tensor_and_nameless(
-            stream_tensor_3d_fixture,
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
             torch.masked_select,
             mask=torch.tensor([False, False, True]).unsqueeze(0).unsqueeze(1),
-        )
-
-
-class TestFlatten:
-    def test_flatten_batch(self, stream_tensor_3d_fixture):
-        assert_tensor_and_nameless(stream_tensor_3d_fixture, torch.flatten, start_dim=0, end_dim=1)
-
-    def test_flatten_feature(self, stream_tensor_4d_fixture, stream_meta_kwargs_fixture):
-        stream_meta_kwargs_fixture["names"] = (BATCH, "F_D", LENGTH)
-        
-        assert_stream_tensor_and_meta_correct(
-            stream_tensor_4d_fixture,
-            torch.flatten,
-            start_dim=1,
-            end_dim=2,
-            **stream_meta_kwargs_fixture,
-        )
-
-
-class TestUnsqueeze:
-    def test_unsqueeze_single(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        stream_meta_kwargs_fixture["names"] = (None, BATCH, "F", LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            stream_tensor_3d_fixture,
-            torch.unsqueeze,
-            dim=0,
-            **stream_meta_kwargs_fixture,
-        )
-
-    def test_unsqueeze_two(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, "F", LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            stream_tensor_3d_fixture.unsqueeze(0),
-            torch.unsqueeze,
-            dim=0,
-            **stream_meta_kwargs_fixture,
-        )
-
-    def test_unsqueeze_three(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, None, "F", LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            stream_tensor_3d_fixture.unsqueeze(0).unsqueeze(2),
-            torch.unsqueeze,
-            dim=0,
-            **stream_meta_kwargs_fixture,
-        )
-
-
-class TestSqueeze:
-    def test_squeeze_non_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            stream_tensor_3d_fixture,
-            torch.squeeze,
-            dim=0,
-            **stream_meta_kwargs_fixture,
-        )
-
-    def test_squeeze_singleton_dim(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        s = as_stream_tensor(
-            stream_tensor_3d_fixture.tensor().sum(dim=1, keepdim=True),
-            names=stream_tensor_3d_fixture.names,
-            meta=stream_tensor_3d_fixture.meta,
-        )
-        stream_meta_kwargs_fixture["names"] = (BATCH, LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            s,
-            torch.squeeze,
-            dim=1,
-            **stream_meta_kwargs_fixture,
-        )
-
-    def test_squeeze_all_singleton_dims(self, stream_tensor_3d_fixture, stream_meta_kwargs_fixture):
-        names = (None, None) + stream_tensor_3d_fixture.names
-        s = as_stream_tensor(
-            stream_tensor_3d_fixture.unsqueeze(0).unsqueeze(0), names=names, meta=stream_tensor_3d_fixture.meta
-        )
-        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
-        assert_stream_tensor_and_meta_correct(
-            s,
-            torch.squeeze,
-            **stream_meta_kwargs_fixture,
         )
 
 
@@ -555,197 +533,197 @@ class TestSqueeze:
 
 
 class TestGetitem:
-    def test_feature_indexing_integer(self, stream_tensor_3d_fixture):
+    def test_feature_indexing_integer(self, stream_tensor_bfl_fixture):
         """Indexing with an integer on the feature dim should remove the feature dim but not change the meta."""
-        s1 = stream_tensor_3d_fixture[:, 0, :]
+        s1 = stream_tensor_bfl_fixture[:, 0, :]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, :])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, 0, :])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 3, 2]))
         assert s1.names == (BATCH, LENGTH)
 
-    def test_batch_indexing_integer(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_integer(self, stream_tensor_bfl_fixture):
         """Indexing with an integer on the batch dim should remove the batch dim and change the meta to have only that
         one example's metadata."""
-        s1 = stream_tensor_3d_fixture[0]
+        s1 = stream_tensor_bfl_fixture[0]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[0])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[0])
         assert s1.meta.ids == ["first"]  # changed to only the first example
         assert torch.equal(s1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == ("F", LENGTH)
 
-    def test_batch_indexing_slice(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_slice(self, stream_tensor_bfl_fixture):
         """Indexing with a slice on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d_fixture[1:]
+        s1 = stream_tensor_bfl_fixture[1:]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[1:])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[1:])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_tuple(self, stream_tensor_3d_fixture):
-        s1 = stream_tensor_3d_fixture[(0,)]
+    def test_batch_indexing_tuple(self, stream_tensor_bfl_fixture):
+        s1 = stream_tensor_bfl_fixture[(0,)]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[(0,)])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[(0,)])
         assert s1.meta.ids == ["first"]
         assert torch.equal(s1.meta.sos, torch.tensor([True]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == ("F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[(0, 1)]
+        s2 = stream_tensor_bfl_fixture[(0, 1)]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1)])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[(0, 1)])
         assert s2.meta.ids == ["first"]
         assert torch.equal(s2.meta.sos, torch.tensor([True]))
         assert torch.equal(s2.meta.eos, torch.tensor([False]))
         assert torch.equal(s2.meta.lengths, torch.tensor([3]))
         assert s2.names == (LENGTH,)
 
-        s3 = stream_tensor_3d_fixture[(0, 1, 2)]
+        s3 = stream_tensor_bfl_fixture[(0, 1, 2)]
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1, 2)])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[(0, 1, 2)])
         assert s3.meta.ids == ["first"]
         assert torch.equal(s3.meta.sos, torch.tensor([False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False]))
         assert torch.equal(s3.meta.lengths, torch.tensor([1]))
         assert s3.names == tuple()
 
-        s4 = stream_tensor_3d_fixture[(0, 1, 0)]
+        s4 = stream_tensor_bfl_fixture[(0, 1, 0)]
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[(0, 1, 0)])
+        assert torch.equal(s4.tensor(), stream_tensor_bfl_fixture.tensor()[(0, 1, 0)])
         assert s4.meta.ids == ["first"]
         assert torch.equal(s4.meta.sos, torch.tensor([True]))
         assert torch.equal(s4.meta.eos, torch.tensor([False]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1]))
         assert s4.names == tuple()
 
-    def test_batch_indexing_list(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_list(self, stream_tensor_bfl_fixture):
         """Indexing with a list or tuple on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d_fixture[[1]]
+        s1 = stream_tensor_bfl_fixture[[1]]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[[1]])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[[1]])
         assert s1.meta.ids == ["middle"]
         assert torch.equal(s1.meta.sos, torch.tensor([False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[[0, 2]]
+        s2 = stream_tensor_bfl_fixture[[0, 2]]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[[0, 2]])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[[0, 2]])
         assert s2.meta.ids == ["first", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([3, 2]))
         assert s2.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_booltensor(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_booltensor(self, stream_tensor_bfl_fixture):
         """Indexing with a bool tensor on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d_fixture[torch.tensor([False, True, True])]
+        s1 = stream_tensor_bfl_fixture[torch.tensor([False, True, True])]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[torch.tensor([False, True, True])])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[torch.tensor([False, True, True])])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_batch_indexing_inttensor(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_inttensor(self, stream_tensor_bfl_fixture):
         """Indexing with an int tensor on the batch dim should remove relevant examples from the meta."""
-        s1 = stream_tensor_3d_fixture[torch.tensor([1, 2])]
+        s1 = stream_tensor_bfl_fixture[torch.tensor([1, 2])]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[torch.tensor([1, 2])])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[torch.tensor([1, 2])])
         assert s1.meta.ids == ["middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([3, 2]))
         assert s1.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_integer(self, stream_tensor_3d_fixture):
+    def test_length_indexing_integer(self, stream_tensor_bfl_fixture):
         """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
         or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the
         last non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?).
         """
-        s2 = stream_tensor_3d_fixture[:, :, 0]  # first length index
+        s2 = stream_tensor_bfl_fixture[:, :, 0]  # first length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 0])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, 0])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s2.names == (BATCH, "F")
 
-        s3 = stream_tensor_3d_fixture[:, :, 1]  # middle length index
+        s3 = stream_tensor_bfl_fixture[:, :, 1]  # middle length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, 1])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s3.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s3.names == (BATCH, "F")
 
-        s4 = stream_tensor_3d_fixture[:, :, -1]  # last length index
+        s4 = stream_tensor_bfl_fixture[:, :, -1]  # last length index
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[:, :, -1])
+        assert torch.equal(s4.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, -1])
         assert s4.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # change to False
         assert torch.equal(s4.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 0]))  # changed to 1 and 0
         assert s4.names == (BATCH, "F")
 
-    def test_length_indexing_slice(self, stream_tensor_3d_fixture):
+    def test_length_indexing_slice(self, stream_tensor_bfl_fixture):
         """Indexing with a slice on the length dim should correctly adjust the meta lengths and sos/eos.
         Specifically,
         - if the slice starts after the first index, no examples should be first.
         - if the slice ends before the last index, no examples should be last.
         - the lengths should be minus the number of non-padding tensor elements that are removed.
         """
-        s2 = stream_tensor_3d_fixture[:, :, 1:]  # remove first length index
+        s2 = stream_tensor_bfl_fixture[:, :, 1:]  # remove first length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1:])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, 1:])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all)
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d_fixture[:, :, :-1]  # remove last length index
+        s3 = stream_tensor_bfl_fixture[:, :, :-1]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, :-1])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, :-1])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-        s4 = stream_tensor_3d_fixture[:, :, 1:-1]  # remove first and last length index
+        s4 = stream_tensor_bfl_fixture[:, :, 1:-1]  # remove first and last length index
         assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor()[:, :, 1:-1])
+        assert torch.equal(s4.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, 1:-1])
         assert s4.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s4.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 1]))  # minus 2 for all but "last" since it was padding
         assert s4.names == (BATCH, "F", LENGTH)
 
-        s5 = stream_tensor_3d_fixture[:, :, :-2]  # remove two last length indices
+        s5 = stream_tensor_bfl_fixture[:, :, :-2]  # remove two last length indices
         assert isinstance(s5, StreamTensor)
-        assert torch.equal(s5.tensor(), stream_tensor_3d_fixture.tensor()[:, :, :-2])
+        assert torch.equal(s5.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, :-2])
         assert s5.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s5.meta.sos, torch.tensor([True, False, False]))  # changed to False
         assert torch.equal(s5.meta.eos, torch.tensor([False, False, False]))
         assert torch.equal(s5.meta.lengths, torch.tensor([1, 1, 1]))  # minus 2 for all but "last" since it was padding
         assert s5.names == (BATCH, "F", LENGTH)
 
-        s6 = stream_tensor_3d_fixture[:, :, ::2]  # remove every other length index from start to end
+        s6 = stream_tensor_bfl_fixture[:, :, ::2]  # remove every other length index from start to end
         assert isinstance(s6, StreamTensor)
-        assert torch.equal(s6.tensor(), stream_tensor_3d_fixture.tensor()[:, :, ::2])
+        assert torch.equal(s6.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, ::2])
         assert s6.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s6.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s6.meta.eos, torch.tensor([False, False, True]))
@@ -759,175 +737,119 @@ class TestGetitem:
             [tuple((1, 2)), tuple((0, 2)), tuple((0, 1))],
         ],
     )
-    def test_length_indexing_tuple_list(self, stream_tensor_3d_fixture, indices):
+    def test_length_indexing_tuple_list(self, stream_tensor_bfl_fixture, indices):
         """"""
-        s1 = stream_tensor_3d_fixture[:, :, indices[0]]  # remove first length index
+        s1 = stream_tensor_bfl_fixture[:, :, indices[0]]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[0]])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, indices[0]])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[:, :, indices[1]]  # remove middle length index
+        s2 = stream_tensor_bfl_fixture[:, :, indices[1]]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[1]])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, indices[1]])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d_fixture[:, :, indices[2]]  # remove last length index
+        s3 = stream_tensor_bfl_fixture[:, :, indices[2]]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, indices[2]])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, indices[2]])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_list(self, stream_tensor_3d_fixture):
+    def test_length_indexing_list(self, stream_tensor_bfl_fixture):
         """"""
-        s1 = stream_tensor_3d_fixture[:, :, [1, 2]]  # remove first length index
+        s1 = stream_tensor_bfl_fixture[:, :, [1, 2]]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [1, 2]])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, [1, 2]])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[:, :, [0, 2]]  # remove middle length index
+        s2 = stream_tensor_bfl_fixture[:, :, [0, 2]]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [0, 2]])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, [0, 2]])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d_fixture[:, :, [0, 1]]  # remove last length index
+        s3 = stream_tensor_bfl_fixture[:, :, [0, 1]]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, [0, 1]])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, [0, 1]])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_1d_inttensor(self, stream_tensor_3d_fixture):
+    def test_length_indexing_1d_inttensor(self, stream_tensor_bfl_fixture):
         """"""
-        s1 = stream_tensor_3d_fixture[:, :, torch.tensor([1, 2])]  # remove first length index
+        s1 = stream_tensor_bfl_fixture[:, :, torch.tensor([1, 2])]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([1, 2])])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, torch.tensor([1, 2])])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[:, :, torch.tensor([0, 2])]  # remove middle length index
+        s2 = stream_tensor_bfl_fixture[:, :, torch.tensor([0, 2])]  # remove middle length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([0, 2])])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, torch.tensor([0, 2])])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s2.names == (BATCH, "F", LENGTH)
 
-        s3 = stream_tensor_3d_fixture[:, :, torch.tensor([0, 1])]  # remove last length index
+        s3 = stream_tensor_bfl_fixture[:, :, torch.tensor([0, 1])]  # remove last length index
         assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([0, 1])])
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, torch.tensor([0, 1])])
         assert s3.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s3.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s3.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but "last" since it was padding
         assert s3.names == (BATCH, "F", LENGTH)
 
-    def test_length_indexing_1d_booltensor(self, stream_tensor_3d_fixture):
+    def test_length_indexing_1d_booltensor(self, stream_tensor_bfl_fixture):
         """Test that we can index a StreamTensor with a bool tensor (mask)."""
-        s1 = stream_tensor_3d_fixture[:, :, torch.tensor([False, True, True])]  # remove first length index
+        s1 = stream_tensor_bfl_fixture[:, :, torch.tensor([False, True, True])]  # remove first length index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([False, True, True])])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, torch.tensor([False, True, True])])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, "F", LENGTH)
 
-        s2 = stream_tensor_3d_fixture[:, :, torch.tensor([True, True, False])]  # remove last length index
+        s2 = stream_tensor_bfl_fixture[:, :, torch.tensor([True, True, False])]  # remove last length index
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, :, torch.tensor([True, True, False])])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, :, torch.tensor([True, True, False])])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s2.meta.lengths, torch.tensor([2, 2, 2]))  # minus 1 for all but last since this was padding.
         assert s2.names == (BATCH, "F", LENGTH)
 
-    def test_indexing_ellipsis(self, stream_tensor_3d_fixture):
-        """Test that we can index a StreamTensor with an ellipsis."""
-        s1_1 = stream_tensor_3d_fixture[0, ...]  # keep only first batch example
-        assert isinstance(s1_1, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, ...])
-        assert s1_1.meta.ids == ["first"]
-        assert torch.equal(s1_1.meta.sos, torch.tensor([True]))
-        assert torch.equal(s1_1.meta.eos, torch.tensor([False]))
-        assert torch.equal(s1_1.meta.lengths, torch.tensor([3]))
-        assert s1_1.names == ("F", LENGTH)
-
-        s1_2 = stream_tensor_3d_fixture[0, ..., :]  # keep only first batch example
-        assert isinstance(s1_2, StreamTensor)
-        assert torch.equal(s1_2.tensor(), stream_tensor_3d_fixture.tensor()[0, ..., :])
-        assert s1_2.meta.ids == ["first"]
-        assert torch.equal(s1_2.meta.sos, torch.tensor([True]))
-        assert torch.equal(s1_2.meta.eos, torch.tensor([False]))
-        assert torch.equal(s1_2.meta.lengths, torch.tensor([3]))
-        assert s1_1.names == ("F", LENGTH)
-
-        s1_3 = stream_tensor_3d_fixture[0, :, ...]  # keep only first batch example
-        assert isinstance(s1_3, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, :, ...])
-        assert s1_3.meta.ids == ["first"]
-        assert torch.equal(s1_3.meta.sos, torch.tensor([True]))
-        assert torch.equal(s1_3.meta.eos, torch.tensor([False]))
-        assert torch.equal(s1_3.meta.lengths, torch.tensor([3]))
-        assert s1_1.names == ("F", LENGTH)
-
-        s1_4 = stream_tensor_3d_fixture[0, ..., ...]  # keep only first batch example
-        assert isinstance(s1_4, StreamTensor)
-        assert torch.equal(s1_1.tensor(), stream_tensor_3d_fixture.tensor()[0, ..., ...])
-        assert s1_4.meta.ids == ["first"]
-        assert torch.equal(s1_4.meta.sos, torch.tensor([True]))
-        assert torch.equal(s1_4.meta.eos, torch.tensor([False]))
-        assert torch.equal(s1_4.meta.lengths, torch.tensor([3]))
-        assert s1_1.names == ("F", LENGTH)
-
-        s2 = stream_tensor_3d_fixture[..., 0]  # keep only first length index
-        assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[..., 0])
-        assert s2.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
-        assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # set to 1
-        assert s2.names == (BATCH, "F")
-
-        s3 = stream_tensor_3d_fixture[..., 0, ...]  # keep only first feature dim
-        assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor()[..., 0, ...])
-        assert s3.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
-        assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
-        assert torch.equal(s3.meta.lengths, torch.tensor([3, 3, 2]))
-        assert s3.names == (BATCH, LENGTH)
-
-    def test_batch_and_feature_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
+    def test_batch_and_feature_indexing_2d_booltensor(self, stream_tensor_bfl_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the batch and feature dimensions."""
         indices = torch.tensor([[True, True], [False, True], [True, False]])  # Keep only some features
-        s1 = stream_tensor_3d_fixture[indices]
+        s1 = stream_tensor_bfl_fixture[indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[indices])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
@@ -935,13 +857,13 @@ class TestGetitem:
         assert s1.shape == (4, 3)
         assert s1.names == (join_dim_names(BATCH, "F"), LENGTH)
 
-    def test_length_and_feature_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
+    def test_length_and_feature_indexing_2d_booltensor(self, stream_tensor_bfl_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the length and feature dimensions."""
         # keep all lenghts of one feature and some of other
         indices = torch.tensor([[True, True, True], [True, False, False]])
-        s1 = stream_tensor_3d_fixture[:, indices]
+        s1 = stream_tensor_bfl_fixture[:, indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
@@ -949,66 +871,34 @@ class TestGetitem:
         assert s1.names == (BATCH, join_dim_names("F", LENGTH))
 
         indices = torch.tensor([[True, False, False], [True, False, False]])  # remove last two time steps of features
-        s2 = stream_tensor_3d_fixture[:, indices]
+        s2 = stream_tensor_bfl_fixture[:, indices]
         assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[:, indices])
         assert s2.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))
         assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s2.names == (BATCH, join_dim_names("F", LENGTH))
 
-    def test_batch_and_length_indexing_2d_booltensor(self, stream_tensor_3d_fixture):
+    def test_batch_and_length_indexing_2d_booltensor(self, stream_tensor_lbf_fixture, stream_tensor_blf_fixture):
         """Test that we can index a StreamTensor with a 2d bool tensor along the length and feature dimensions."""
-        # sos=[True, False, False], eos=[False, False, True],
-        indices = torch.tensor([[True, True, True], [True, False, False], [True, True, True]])  # (B, T) = (3, 3)
-        s1 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
-        s1 = s1[indices]  # (B, T, F) -> (B_T, F)
-        assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
-        assert s1.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
-        assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
-        assert torch.equal(s1.meta.lengths, torch.tensor([3, 1, 2]))  # changed to 1
-        assert s1.names == (join_dim_names(BATCH, LENGTH), "F")
+        # Remove last two steps of middle example
+        indices = torch.tensor([[True, True, True], [True, False, False], [True, True, True]])  # (L, B) = (3, 3)
+        assert_fallback_to_torch_tensor(stream_tensor_lbf_fixture, torch.Tensor.__getitem__, indices)
 
         # Remove middle example altogether
-        indices = torch.tensor([[True, True, True], [False, False, False], [True, True, True]])  # (B, T) = (3, 3)
-        s2 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
-        s2 = s2[indices]  # (B, T, F) -> (B_T, F)
-        assert isinstance(s2, StreamTensor)
-        assert torch.equal(s2.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
-        assert s2.meta.ids == ["first", "last"]
-        assert torch.equal(s2.meta.sos, torch.tensor([True, False]))
-        assert torch.equal(s2.meta.eos, torch.tensor([False, True]))
-        assert torch.equal(s2.meta.lengths, torch.tensor([3, 2]))
-        assert s2.names == (join_dim_names(BATCH, LENGTH), "F")
+        indices = torch.tensor([[True, True, True], [False, False, False], [True, True, True]])  # (L, B) = (3, 3)
+        assert_fallback_to_torch_tensor(stream_tensor_lbf_fixture, torch.Tensor.__getitem__, indices)
 
         # Remove middle example and first time step of first example and last two timesteps of last example
-        indices = torch.tensor([[False, True, True], [False, False, False], [True, False, False]])  # (B, T) = (3, 3)
-        s3 = stream_tensor_3d_fixture.permute(0, 2, 1)  # (B, F, T) -> (B, T, F)
-        s3 = s3[indices]  # (B, T, F) -> (B_T, F)
-        assert isinstance(s3, StreamTensor)
-        assert torch.equal(s3.tensor(), stream_tensor_3d_fixture.tensor().permute(0, 2, 1)[indices])
-        assert s3.meta.ids == ["first", "last"]
-        assert torch.equal(s3.meta.sos, torch.tensor([False, False]))  # changed to False
-        assert torch.equal(s3.meta.eos, torch.tensor([False, False]))  # changed to False
-        assert torch.equal(s3.meta.lengths, torch.tensor([2, 1]))  # minus 1
-        assert s3.names == (join_dim_names(BATCH, LENGTH), "F")
+        indices = torch.tensor([[False, True, True], [False, False, False], [True, False, False]])  # (L, B) = (3, 3)
+        assert_fallback_to_torch_tensor(stream_tensor_lbf_fixture, torch.Tensor.__getitem__, indices)
 
-        # Transposed version of s3
+        # Transposed version of s3 (stream_tensor_blf instead of stream_tensor_lbf)
         # Remove middle timestep for all examples, include first timestep for middle and last, last timestep for first
-        s4 = stream_tensor_3d_fixture.permute(2, 0, 1)  # (B, F, T) -> (T, B, F)
-        s4 = s4[indices]  # (B, T, F) -> (B_T, F)
-        assert isinstance(s4, StreamTensor)
-        assert torch.equal(s4.tensor(), stream_tensor_3d_fixture.tensor().permute(2, 0, 1)[indices])
-        assert s4.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s4.meta.sos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s4.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s4.meta.lengths, torch.tensor([1, 1, 1]))  # minus 1
-        assert s4.names == (join_dim_names(LENGTH, BATCH), "F")
+        assert_fallback_to_torch_tensor(stream_tensor_blf_fixture, torch.Tensor.__getitem__, indices)
 
-    def test_batch_and_length_indexing_3d_booltensor(self, stream_tensor_3d_fixture):
+    def test_batch_and_length_indexing_3d_booltensor(self, stream_tensor_bfl_fixture):
         """Test indexing a StreamTensor with a 3D BoolTensor along the batch, feature and length dimensions."""
         indices = torch.tensor(
             [
@@ -1026,20 +916,14 @@ class TestGetitem:
                 ],
             ]
         )  # (B, T) = (3, 3)
-        s1 = stream_tensor_3d_fixture[indices]  # (B, T, F) -> (B_T, F)
-        assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[indices])
-        assert s1.meta.ids == ["first", "middle", "last"]
-        assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
-        assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))  # changed to False
-        assert torch.equal(s1.meta.lengths, torch.tensor([3, 1, 1]))  # changed to 1
-        assert s1.names == (join_dim_names(BATCH, "F", LENGTH),)
 
-    def test_feature_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
+        assert_fallback_to_torch_tensor(stream_tensor_bfl_fixture, torch.Tensor.__getitem__, indices)
+
+    def test_feature_indexing_2d_inttensor(self, stream_tensor_bfl_fixture):
         indices = torch.tensor([[0, 1], [1, 1]])
-        s1 = stream_tensor_3d_fixture[:, indices]
+        s1 = stream_tensor_bfl_fixture[:, indices]
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, indices])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, indices])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
@@ -1047,53 +931,344 @@ class TestGetitem:
         assert s1.names == (BATCH, None, "F", LENGTH)
         assert s1.shape == (3, 2, 2, 3)
 
-    def test_batch_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
+    def test_batch_indexing_2d_inttensor(self, stream_tensor_bfl_fixture):
         indices = torch.tensor([[0, 1, 2], [0, 1, 2]])
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture[indices]
+            stream_tensor_bfl_fixture[indices]
 
-    def test_length_indexing_2d_inttensor(self, stream_tensor_3d_fixture):
+    def test_length_indexing_2d_inttensor(self, stream_tensor_bfl_fixture):
         indices = torch.tensor([[0, 1], [1, 1]])
         with pytest.raises(IndexError):
-            stream_tensor_3d_fixture[..., indices]
+            stream_tensor_bfl_fixture[..., indices]
 
-    def test_length_indexing_integer_multidimensional(self, stream_tensor_3d_fixture):
+    def test_length_indexing_integer_multidimensional(self, stream_tensor_bfl_fixture):
         """Indexing with an integer on the length dim should remove the length dim and change the meta to have lengths 1
         or 0 depending on padding, and sos only true when the index is 0, and eos only true when the index is the last
         non-padding index or beyond (TODO (JDH): Maybe we want eos False if in padding?). This case also tests that we
         can simultaneously index the feature dimension without affecting the length indexing.
         """
-        s1 = stream_tensor_3d_fixture[:, 0, 0]  # first length index and first feature index
+        s1 = stream_tensor_bfl_fixture[:, 0, 0]  # first length index and first feature index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, 0])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, 0, 0])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([True, False, False]))
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.lengths, torch.tensor([1, 1, 1]))  # changed to 1
         assert s1.names == (BATCH,)
 
-    def test_length_indexing_slice_multidimensional(self, stream_tensor_3d_fixture):
+    def test_length_indexing_slice_multidimensional(self, stream_tensor_bfl_fixture):
         """Indexing with a slice on the length dim should correctly adjust the meta lengths and sos/eos.
         This case also tests that we can simultaneously index the feature dimension without affecting the length
         indexing.
         """
-        s1 = stream_tensor_3d_fixture[:, 0, 1:]  # remove first length index and first feature index
+        s1 = stream_tensor_bfl_fixture[:, 0, 1:]  # remove first length index and first feature index
         assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:, 0, 1:])
+        assert torch.equal(s1.tensor(), stream_tensor_bfl_fixture.tensor()[:, 0, 1:])
         assert s1.meta.ids == ["first", "middle", "last"]
         assert torch.equal(s1.meta.sos, torch.tensor([False, False, False]))  # changed to False
         assert torch.equal(s1.meta.eos, torch.tensor([False, False, True]))
         assert torch.equal(s1.meta.lengths, torch.tensor([2, 2, 1]))  # minus 1 for all
         assert s1.names == (BATCH, LENGTH)
 
-    def test_batch_and_length_indexing_slice(self, stream_tensor_3d_fixture):
+    def test_batch_and_length_indexing_slice(self, stream_tensor_bfl_fixture):
         """Indexing with a slice on the batch dim and a slice on the length dim should have the combined effect of
         both."""
-        s1 = stream_tensor_3d_fixture[:-1, :, 1:]  # remove last batch index and first length index
-        assert isinstance(s1, StreamTensor)
-        assert torch.equal(s1.tensor(), stream_tensor_3d_fixture.tensor()[:-1, :, 1:])
-        assert s1.meta.ids == ["first", "middle"]
-        assert torch.equal(s1.meta.sos, torch.tensor([False, False]))
-        assert torch.equal(s1.meta.eos, torch.tensor([False, False]))
-        assert torch.equal(s1.meta.lengths, torch.tensor([2, 2]))
-        assert s1.names == (BATCH, "F", LENGTH)
+        # Remove last batch index and first length index
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (slice(None, -1), slice(None), slice(1, None)),  # [:-1, :, 1:]
+            ids=["first", "middle"],
+            sos=torch.tensor([False, False]),
+            eos=torch.tensor([False, False]),
+            lengths=torch.tensor([2, 2]),
+            names=(BATCH, "F", LENGTH),
+        )
+
+    def test_indexing_ellipsis(self, stream_tensor_bfl_fixture):
+        """Test that we can index a StreamTensor with an ellipsis."""
+        s1_1 = stream_tensor_bfl_fixture[0, ...]  # keep only first batch example
+        assert isinstance(s1_1, StreamTensor)
+        assert torch.equal(s1_1.tensor(), stream_tensor_bfl_fixture.tensor()[0, ...])
+        assert s1_1.meta.ids == ["first"]
+        assert torch.equal(s1_1.meta.sos, torch.tensor([True]))
+        assert torch.equal(s1_1.meta.eos, torch.tensor([False]))
+        assert torch.equal(s1_1.meta.lengths, torch.tensor([3]))
+        assert s1_1.names == ("F", LENGTH)
+
+        s1_2 = stream_tensor_bfl_fixture[0, ..., :]  # keep only first batch example
+        assert isinstance(s1_2, StreamTensor)
+        assert torch.equal(s1_2.tensor(), stream_tensor_bfl_fixture.tensor()[0, ..., :])
+        assert s1_2.meta.ids == ["first"]
+        assert torch.equal(s1_2.meta.sos, torch.tensor([True]))
+        assert torch.equal(s1_2.meta.eos, torch.tensor([False]))
+        assert torch.equal(s1_2.meta.lengths, torch.tensor([3]))
+        assert s1_1.names == ("F", LENGTH)
+
+        s1_3 = stream_tensor_bfl_fixture[0, :, ...]  # keep only first batch example
+        assert isinstance(s1_3, StreamTensor)
+        assert torch.equal(s1_1.tensor(), stream_tensor_bfl_fixture.tensor()[0, :, ...])
+        assert s1_3.meta.ids == ["first"]
+        assert torch.equal(s1_3.meta.sos, torch.tensor([True]))
+        assert torch.equal(s1_3.meta.eos, torch.tensor([False]))
+        assert torch.equal(s1_3.meta.lengths, torch.tensor([3]))
+        assert s1_1.names == ("F", LENGTH)
+
+        s1_4 = stream_tensor_bfl_fixture[0, ..., ...]  # keep only first batch example
+        assert isinstance(s1_4, StreamTensor)
+        assert torch.equal(s1_1.tensor(), stream_tensor_bfl_fixture.tensor()[0, ..., ...])
+        assert s1_4.meta.ids == ["first"]
+        assert torch.equal(s1_4.meta.sos, torch.tensor([True]))
+        assert torch.equal(s1_4.meta.eos, torch.tensor([False]))
+        assert torch.equal(s1_4.meta.lengths, torch.tensor([3]))
+        assert s1_1.names == ("F", LENGTH)
+
+        s2 = stream_tensor_bfl_fixture[..., 0]  # keep only first length index
+        assert isinstance(s2, StreamTensor)
+        assert torch.equal(s2.tensor(), stream_tensor_bfl_fixture.tensor()[..., 0])
+        assert s2.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s2.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s2.meta.eos, torch.tensor([False, False, False]))  # changed to False
+        assert torch.equal(s2.meta.lengths, torch.tensor([1, 1, 1]))  # set to 1
+        assert s2.names == (BATCH, "F")
+
+        s3 = stream_tensor_bfl_fixture[..., 0, ...]  # keep only first feature dim
+        assert isinstance(s3, StreamTensor)
+        assert torch.equal(s3.tensor(), stream_tensor_bfl_fixture.tensor()[..., 0, ...])
+        assert s3.meta.ids == ["first", "middle", "last"]
+        assert torch.equal(s3.meta.sos, torch.tensor([True, False, False]))
+        assert torch.equal(s3.meta.eos, torch.tensor([False, False, True]))
+        assert torch.equal(s3.meta.lengths, torch.tensor([3, 3, 2]))
+        assert s3.names == (BATCH, LENGTH)
+
+    def test_indexing_none(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        # Insert single new dimension before left most dimension.
+        stream_meta_kwargs_fixture["names"] = (None, BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            None,
+            **stream_meta_kwargs_fixture,
+        )
+
+        # Insert two new dimensions before left most dimension.
+        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (None, None),
+            **stream_meta_kwargs_fixture,
+        )
+
+        # Insert single new dimension at dim 1.
+        stream_meta_kwargs_fixture["names"] = (BATCH, None, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (slice(None), None),
+            **stream_meta_kwargs_fixture,
+        )
+
+        # Insert single new dimension at dim 2.
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", None, LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (slice(None), slice(None), None),
+            **stream_meta_kwargs_fixture,
+        )
+
+        # Insert single new dimension at dim 3 (right most dimension) using.
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH, None)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (slice(None), slice(None), slice(None), None),
+            **stream_meta_kwargs_fixture,
+        )
+
+        # Insert single new dimension at dim 3 (right most dimension) using Ellipsis.
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH, None)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.__getitem__,
+            (..., None),
+            **stream_meta_kwargs_fixture,
+        )
+
+
+class TestScatterAdd:
+    batch_index = torch.tensor([[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]])
+    feature_index = torch.tensor([[[0, 1, 0], [0, 1, 0]], [[0, 1, 0], [0, 1, 0]], [[0, 1, 0], [0, 1, 0]]])
+    src = stream_tensor_bfl() * 2
+
+    def test_scatter_add_batch(self, stream_tensor_bfl_fixture):
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture, torch.scatter_add, dim=0, index=self.batch_index, src=self.src
+        )
+
+    def test_scatter_add_feature(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.scatter_add,
+            dim=1,
+            index=self.feature_index,
+            src=self.src,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_scatter_add_length(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
+            torch.scatter_add,
+            dim=2,
+            index=self.feature_index,
+            src=self.src,
+        )
+
+    def test_scatter_add_feature_inplace(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.scatter_add_,
+            dim=1,
+            index=self.feature_index,
+            src=self.src,
+            **stream_meta_kwargs_fixture,
+        )
+
+
+@pytest.mark.parametrize("reduce", ["sum", "mean", "max", "min"])
+class TestScatterReduce:
+    batch_index = torch.tensor([[[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]], [[0, 1, 2], [0, 1, 2]]])
+    feature_index = torch.tensor([[[0, 1, 0], [0, 1, 0]], [[0, 1, 0], [0, 1, 0]], [[0, 1, 0], [0, 1, 0]]])
+    src = stream_tensor_bfl() * 2
+
+    def test_scatter_reduce_batch(self, stream_tensor_bfl_fixture, reduce):
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
+            torch.scatter_reduce,
+            dim=0,
+            index=self.batch_index,
+            src=self.src,
+            reduce=reduce,
+        )
+
+    def test_scatter_reduce_feature(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture, reduce):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.scatter_reduce,
+            dim=1,
+            index=self.feature_index,
+            src=self.src,
+            reduce=reduce,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_scatter_reduce_length(self, stream_tensor_bfl_fixture, reduce):
+        assert_fallback_to_torch_tensor(
+            stream_tensor_bfl_fixture,
+            torch.scatter_reduce,
+            dim=2,
+            index=self.feature_index,
+            src=self.src,
+            reduce=reduce,
+        )
+
+    def test_scatter_reduce_feature_inplace(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture, reduce):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.Tensor.scatter_reduce_,
+            dim=1,
+            index=self.feature_index,
+            src=self.src,
+            reduce=reduce,
+            **stream_meta_kwargs_fixture,
+        )
+
+
+class TestFlatten:
+    def test_flatten_batch(self, stream_tensor_bfld_fixture):
+        assert_fallback_to_torch_tensor(stream_tensor_bfld_fixture, torch.flatten, start_dim=0, end_dim=1)
+
+    def test_flatten_feature(self, stream_tensor_bfld_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F_D", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfld_fixture,
+            torch.flatten,
+            start_dim=1,
+            end_dim=2,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_flatten_length(self, stream_tensor_bfld_fixture):
+        assert_fallback_to_torch_tensor(stream_tensor_bfld_fixture, torch.flatten, start_dim=2, end_dim=3)
+
+
+class TestUnsqueeze:
+    def test_unsqueeze_single(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_unsqueeze_two(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture.unsqueeze(0),
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_unsqueeze_three(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (None, None, BATCH, None, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture.unsqueeze(0).unsqueeze(2),
+            torch.unsqueeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+
+class TestSqueeze:
+    def test_squeeze_non_singleton_dim(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            stream_tensor_bfl_fixture,
+            torch.squeeze,
+            dim=0,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_squeeze_singleton_dim(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        s = as_stream_tensor(
+            stream_tensor_bfl_fixture.tensor().sum(dim=1, keepdim=True),
+            names=stream_tensor_bfl_fixture.names,
+            meta=stream_tensor_bfl_fixture.meta,
+        )
+        stream_meta_kwargs_fixture["names"] = (BATCH, LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            s,
+            torch.squeeze,
+            dim=1,
+            **stream_meta_kwargs_fixture,
+        )
+
+    def test_squeeze_all_singleton_dims(self, stream_tensor_bfl_fixture, stream_meta_kwargs_fixture):
+        names = (None, None) + stream_tensor_bfl_fixture.names
+        s = as_stream_tensor(
+            stream_tensor_bfl_fixture.unsqueeze(0).unsqueeze(0), names=names, meta=stream_tensor_bfl_fixture.meta
+        )
+        stream_meta_kwargs_fixture["names"] = (BATCH, "F", LENGTH)
+        assert_stream_tensor_and_meta_correct(
+            s,
+            torch.squeeze,
+            **stream_meta_kwargs_fixture,
+        )

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -161,11 +161,35 @@ TEST_INPUTS_RECOUPLE_FUNCTIONS = {
         index=torch.tensor([[0, 1, 2], [0, 1, 2]]),
         src=stream_tensor_bl() * 2,
     ),
+    torch.diagonal_scatter: Inputs(
+        input=stream_tensor_bl(),
+        src=stream_tensor_bl().tensor()[:, 0] * 2,
+        offset=0,
+        dim1=0,
+        dim2=1,
+    ),
+    torch.select_scatter: Inputs(
+        input=stream_tensor_bl(),
+        src=stream_tensor_bl().tensor()[:, 0] * 2,
+        dim=0,
+        index=1,
+    ),
+    torch.slice_scatter: Inputs(
+        input=stream_tensor_bl(),
+        src=stream_tensor_bl().tensor() * 2,
+        dim=0,
+        start=0,
+        end=3,
+        step=1,
+    ),
 }
 
 
 TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.scatter_] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.scatter]
 TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.scatter] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.scatter]
+TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.diagonal_scatter] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.diagonal_scatter]
+TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.select_scatter] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.select_scatter]
+TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.Tensor.slice_scatter] = TEST_INPUTS_RECOUPLE_FUNCTIONS[torch.slice_scatter]
 
 
 TEST_SKIP_EQUALITY_CHECK = {torch.Tensor.__repr__}


### PR DESCRIPTION
This PR adds overrides to the following indexing functions:

```
- narrow
- gather
- select
- select_copy
- index_select
- take
- take_along_dim
- masked_select
- scatter
- diagonal_scatter
- select_scatter
- slice_scatter
- scatter_add
- scatter_reduce
- squeeze
- unsqueeze
- flatten
```